### PR TITLE
Add main nav

### DIFF
--- a/apps/core/factories.py
+++ b/apps/core/factories.py
@@ -10,7 +10,6 @@ from wagtail.core.models import Locale, Page, Site
 from apps.core.models import ContentPage, HomePage
 
 fake = Faker()
-Faker.seed(0)
 
 
 class LocaleFactory(factory.django.DjangoModelFactory):

--- a/apps/core/management/commands/buildfixtures.py
+++ b/apps/core/management/commands/buildfixtures.py
@@ -4,11 +4,14 @@ import uuid
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.template.defaultfilters import slugify
+from faker import Faker
 from wagtail.documents import get_document_model
 from wagtail.images import get_image_model
 from wagtail.models import Collection, Locale, Page
 
 from apps.core.factories import ContentPageFactory, HomePageFactory
+
+fake = Faker()
 
 
 class Command(BaseCommand):
@@ -39,9 +42,28 @@ class Command(BaseCommand):
         for title, subpage_titles in [
             [
                 "Tutorial",
-                ["Introduction", "Getting started", "Finding your way around"],
+                [
+                    "Getting started",
+                    "Dashboard",
+                    "Images",
+                    "Documents",
+                    "Page explorer",
+                    "Page editor",
+                    "Search",
+                ],
             ],
-            ["How-to", ["Add a user", "Assign permissions" "Tag content"]],
+            [
+                "How-to",
+                [
+                    "Add a user",
+                    "Assign permissions",
+                    "Create rich text",
+                    "Work with collections",
+                    "Tag content",
+                    "Add a focus area to an image",
+                    "Order pages",
+                ],
+            ],
             [
                 "Explanation",
                 [
@@ -53,8 +75,9 @@ class Command(BaseCommand):
             [
                 "Reference",
                 [
-                    "Dashboard",
-                    "Page editor",
+                    "Glossary",
+                    "Rich text shortcuts",
+                    "Groups and permissions",
                     "Workflows",
                 ],
             ],
@@ -70,7 +93,6 @@ class Command(BaseCommand):
                     title=subpage_title,
                     slug=slugify(subpage_title),
                 )
-
             self.home.sections = json.dumps(
                 [
                     {

--- a/apps/core/models/content.py
+++ b/apps/core/models/content.py
@@ -6,6 +6,7 @@ from ..blocks import CONTENT_BLOCKS
 
 
 class ContentPage(Page):
+    show_in_menus_default = True
     subpage_types = ["core.ContentPage"]
 
     body = StreamField(

--- a/apps/core/templates/base.html
+++ b/apps/core/templates/base.html
@@ -30,7 +30,9 @@
         {% include "components/header.html" %}
 
         <div class="container-lg px-md-5">
+          <div class="row">
           {% block content %}{% endblock %}
+          </div>
         </div>
 
         {# Global javascript #}

--- a/apps/core/templates/components/navigation.html
+++ b/apps/core/templates/components/navigation.html
@@ -1,0 +1,18 @@
+{% load wagtailcore_tags %}
+
+<nav>
+{% for item, info in annotated_list %}
+    {% if info.open %}
+        <ul class="navigation">
+          <li class="navigation__item">
+    {% else %}
+          </li>
+          <li class="navigation__item">
+    {% endif %}
+    <a href="{% pageurl item %}" class="navigation__link{% if info.level == 0 %} navigation__link--large{% endif %}{% if item.id == current_page.id %} active{% endif %}">{{ item }}</a>
+    {% for close in info.close %}
+        </li>
+      </ul>
+    {% endfor %}
+{% endfor %}
+</nav>

--- a/apps/core/templates/core/content_page.html
+++ b/apps/core/templates/core/content_page.html
@@ -1,11 +1,17 @@
 {% extends "base.html" %}
 
-{% load static %}
-{% load wagtailcore_tags %}
+{% load wagtailcore_tags core_tags %}
 
 {% block content %}
+<div class="d-none d-md-block col-md-4 col-lg-2">
+  {% navigation %}
+</div>
+
+<main class="col-md-8 col-lg-6">
   <h1>{{ page.title }}</h1>
   {% for block in page.body %}
     {% include_block block %}
   {% endfor %}
+</main>
+
 {% endblock %}

--- a/apps/core/templatetags/core_tags.py
+++ b/apps/core/templatetags/core_tags.py
@@ -1,0 +1,22 @@
+from django import template
+from django.utils.translation import get_language
+from wagtail.core.models import Page
+
+from apps.core.models import HomePage
+
+register = template.Library()
+
+
+@register.inclusion_tag("components/navigation.html", takes_context=True)
+def navigation(context):
+    home = HomePage.objects.filter(locale__language_code=get_language()).first()
+    pages = (
+        Page.objects.descendant_of(home)
+        .filter(depth__gt=2, depth__lte=4)
+        .live()
+        .in_menu()
+    )
+    return {
+        "current_page": context.get("page"),
+        "annotated_list": Page.get_annotated_list_qs(pages),
+    }

--- a/apps/core/tests/test_management_commands.py
+++ b/apps/core/tests/test_management_commands.py
@@ -9,6 +9,6 @@ class TestBuildFixtures(TestCase):
     def test_build_fixtures(self):
         self.assertEqual(Page.objects.all().count(), 2)
         call_command("buildfixtures")
-        self.assertEqual(Page.objects.all().count(), 22)
+        self.assertGreater(Page.objects.all().count(), 20)
         for page in Page.objects.all().exclude(pk=Page.get_first_root_node().pk):
             self.assertEqual(self.client.get(page.url).status_code, HTTPStatus.OK)

--- a/apps/frontend/static_src/scss/components/navigation.scss
+++ b/apps/frontend/static_src/scss/components/navigation.scss
@@ -1,0 +1,21 @@
+.navigation {
+  @extend .nav;
+  @extend .nav-pills;
+  @extend .flex-column;
+  @extend .mb-3;
+  &__item {
+    @extend .nav-item;
+  }
+  &__link {
+    @extend .nav-link;
+    @extend .small;
+    &:hover {
+      background-color: darken(#edeaf3, 5);
+    }
+    &--large {
+      @extend .mb-1;
+      font-size: $font-size-sm * 1.6;
+      font-weight: 400;
+    }
+  }
+}

--- a/apps/frontend/static_src/scss/main.scss
+++ b/apps/frontend/static_src/scss/main.scss
@@ -18,10 +18,10 @@
 //@import "~bootstrap/scss/tables";
 //@import "~bootstrap/scss/forms";
 @import "~bootstrap/scss/buttons";
-//@import "~bootstrap/scss/transitions";
+@import "~bootstrap/scss/transitions";
 @import "~bootstrap/scss/dropdown";
 // @import "~bootstrap/scss/button-group";
-//@import "~bootstrap/scss/nav";
+@import "~bootstrap/scss/nav";
 //@import "~bootstrap/scss/navbar";
 //@import "~bootstrap/scss/card";
 //@import "~bootstrap/scss/accordion";
@@ -48,4 +48,5 @@
 @import "~bootstrap/scss/utilities/api";
 
 //custom component styles
-@import "./components/section_grid_block.scss";
+@import "./components/section_grid_block";
+@import "./components/navigation";

--- a/apps/frontend/static_src/scss/variables.scss
+++ b/apps/frontend/static_src/scss/variables.scss
@@ -1,6 +1,22 @@
-// Wagtail Guide conf.
-$enable-rounded: false;
-$green:   teal !default;
-$primary: $green;
+// Wagtail Guide Bootstrap defaults.
 
-$body-bg: #EDEAF3;
+// Color system
+$teal:   #007d7e;
+$primary: $teal;
+$body-bg: #edeaf3;
+
+// Typography
+$font-size-root:             null !default;
+$font-size-base:             1rem !default; // Assumes the browser default, typically `16px`
+$font-size-sm:               $font-size-base * .875 !default;
+
+// scss-docs-start nav-variables
+$nav-link-padding-y:                .25rem;
+$nav-link-padding-x:                .5rem;
+$nav-link-font-size:                $font-size-sm;
+$nav-link-font-weight:              600;
+$nav-link-color:                    #262626;
+$nav-link-hover-color:              black;
+$nav-link-color:                    #262626 !default;
+$nav-link-hover-color:              black !default;
+$nav-pills-link-active-bg:          #2e1f5e;


### PR DESCRIPTION
# Screenshot of work done

<img width="1912" alt="Screenshot 2022-07-23 at 21 11 15" src="https://user-images.githubusercontent.com/1969342/180619652-7f505a2f-d374-451a-a7bb-3797e5f07fd9.png">

# Issue

I raised this in our Slack channel. Added it here as archive. 

I tried to create the navigation and am fighting the data structure a bit.
- It is impossible to navigate from 'Tutorials' to 'How-to'. The main navigation is missing.
- The collapsed navigation hide relevant information.
- The collapsed navigation is harder to use. As a user needs to click, click, click to expand the collapsed sections.

In the current guide, the page 'Finding your way around' duplicates the navigation. It is redundant.
https://docs.wagtail.org/en/stable/editor_manual/finding_your_way_around/index.html

If we drop the redundant 'in between pages', we loose a level, we can drop the collapse feature :tada:

Mockup:

<img width="1437" alt="nav" src="https://user-images.githubusercontent.com/1969342/180393053-00fe1e28-d80f-4603-934f-1bebf49e370e.png">

1. The current design.
2. Drop the lowest level, the contents of these pages can be on "Finding your way around".
3. OR, drop "Finding your way around", the underlying pages are lifted to a higher level.
4. Add the section titles. No need for a `+` icon. A click on the item can trigger a page load.

Note, that I couldn't adjust the boldness of the text in Photoshop. "The Explorer menu, ..." should have the same weight as "Introduction, Getting started, ..."

The proposed navigation is simpler. Easier to understand, easier to navigate, and easier to make and maintain.