### PR TITLE
add previous and next buttons

### DIFF
--- a/apps/core/templates/core/content_page.html
+++ b/apps/core/templates/core/content_page.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load wagtailcore_tags core_tags %}
+{% load wagtailcore_tags core_tags manifest %}
 
 {% block content %}
 <div class="d-none d-md-block col-md-4 col-lg-3 pe-md-5">
@@ -12,6 +12,31 @@
   {% for block in page.body %}
     {% include_block block %}
   {% endfor %}
+  <div class="d-flex mt-5 flex-wrap justify-content-between">
+    {% if page|previous_page != None %}
+      <a href="{% pageurl page|previous_page %}" class="text-decoration-none">
+        <button class="nav-button m-1 ms-0">
+          <div class="d-flex justify-content-center align-items-center">
+            <img src="{% manifest 'images/arrow.svg' %}" width="30px" height="25px" class="nav-button__left-arrow">
+            <div class="fw-bold px-2 pe-3">
+              {{ page|previous_page }}
+            </div>
+          </div>
+        </button>
+      </a>
+    {% endif %}
+    {% if page|next_page != None %}
+      <a href="{% pageurl page|next_page %}" class="text-decoration-none">
+        <button class="nav-button m-1 me-0">
+          <div class="d-flex justify-content-center align-items-center">
+            <div class="fw-bold px-2 ps-3">
+              {{ page|next_page }}
+            </div>
+            <img src="{% manifest 'images/arrow.svg' %}" width="30px" height="25px">
+          </div>
+        </button>
+      </a>
+    {% endif %}
 </main>
 
 {% endblock %}

--- a/apps/core/templatetags/core_tags.py
+++ b/apps/core/templatetags/core_tags.py
@@ -20,3 +20,42 @@ def navigation(context):
         "current_page": context.get("page"),
         "annotated_list": Page.get_annotated_list_qs(pages),
     }
+
+
+@register.filter
+def next_page(page):
+    first_descendant = page.get_descendants().live().first()
+    if first_descendant:
+        return first_descendant
+
+    next_sibling = page.get_siblings().live().filter(path__gt=page.path).first()
+    if next_sibling:
+        return next_sibling
+
+    next_section = (
+        page.get_ancestors()
+        .live()
+        .last()
+        .get_siblings()
+        .filter(path__gt=page.path)
+        .first()
+    )
+    if next_section:
+        return next_section
+
+    return None
+
+
+@register.filter
+def previous_page(page):
+    previous_page = page.get_siblings().live().filter(path__lt=page.path).last()
+    if previous_page:
+        last_descendant = previous_page.get_descendants().live().last()
+        if last_descendant:
+            return last_descendant
+        return previous_page
+    parent = page.get_ancestors().live().last()
+    if parent:
+        return parent
+
+    return None

--- a/apps/frontend/static_src/scss/components/nav_button.scss
+++ b/apps/frontend/static_src/scss/components/nav_button.scss
@@ -1,0 +1,15 @@
+.nav-button {
+    @extend .d-flex;
+    @extend .p-2;
+    @extend .bg-transparent;
+    @extend .border;
+    @extend .border-dark;
+    @extend .rounded;
+    &:hover {
+        @extend .bg-dark;
+        @extend .text-light;
+    }
+    .nav-button__left-arrow {
+        transform: rotateZ(180deg);
+    }
+}

--- a/apps/frontend/static_src/scss/main.scss
+++ b/apps/frontend/static_src/scss/main.scss
@@ -50,3 +50,4 @@
 //custom component styles
 @import "./components/section_grid_block";
 @import "./components/navigation";
+@import "./components/nav_button.scss";


### PR DESCRIPTION
I have added previous and next buttons for content pages. For that I have registered 2 filters namely `previous_page` and `next_page` which have their own logic for returning their respective pages. I have designed the buttons according to the design on figma. I have also added a new scss file `nav_button.scss` in `apps/frontend/static_src/scss/components/` for styling and adding hover effects on the buttons. The buttons seemed to be working fine when tested locally.
I am attaching the screenshot of the end result:
![Screenshot from 2022-08-10 23-18-23](https://user-images.githubusercontent.com/76250591/183981497-90f21c6c-ae23-44d6-b5f6-355c5369bd83.png)
