### PR TITLE
Add inline keyboard text style in rich text. Fix #81

### DIFF
--- a/apps/core/wagtail_hooks.py
+++ b/apps/core/wagtail_hooks.py
@@ -1,4 +1,8 @@
+import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail import hooks
+from wagtail.admin.rich_text.converters.html_to_contentstate import (
+    InlineStyleElementHandler,
+)
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 
 from apps.core.models.feedback import Feedback
@@ -19,3 +23,42 @@ modeladmin_register(FeedbackAdmin)
 @hooks.register("register_rich_text_features")
 def register_inline_code_feature(features):
     features.default_features.append("code")
+
+
+@hooks.register("register_rich_text_features")
+def register_keyboard_input_text_style(features):
+    feature_name = "keyboard_input"
+    type_ = "KEYBOARDINPUT"
+    tag = "kbd"
+
+    control = {
+        "type": type_,
+        "label": "⌘",
+        "description": "Keyboard input style",
+        "style": {
+            "background-color": "#eee",
+            "border-radius": "3px",
+            "border": "1px solid #b4b4b4",
+            "box-shadow": "0 1px 1px rgba(0, 0, 0, .2), 0 2px 0 0 rgba(255, 255, 255, .7) inset",  # noqa
+            "color": "#333",
+            "display": "inline-block",
+            "font-size": ".85em",
+            "font-weight": "700",
+            "line-height": "1",
+            "padding": "2px 4px",
+            "white-space": "nowrap",
+        },
+    }
+
+    features.register_editor_plugin(
+        "draftail", feature_name, draftail_features.InlineStyleFeature(control)
+    )
+
+    db_conversion = {
+        "from_database_format": {tag: InlineStyleElementHandler(type_)},
+        "to_database_format": {"style_map": {type_: tag}},
+    }
+
+    features.register_converter_rule("contentstate", feature_name, db_conversion)
+
+    features.default_features.append("keyboard_input")

--- a/apps/frontend/static_src/scss/components/rich-text.scss
+++ b/apps/frontend/static_src/scss/components/rich-text.scss
@@ -3,3 +3,18 @@ code {
     // https://github.com/wagtail/wagtail/blob/849d4d71cae41de56e43832546429cbb8ad289d5/client/src/tokens/typography.js#L38
     font-family: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono", "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro", "Fira Mono", "Droid Sans Mono", "Courier New", monospace, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
+
+kbd {
+    // From https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd
+    background-color: #eee;
+    border-radius: 3px;
+    border: 1px solid #b4b4b4;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, .2), 0 2px 0 0 rgba(255, 255, 255, .7) inset;
+    color: #333;
+    display: inline-block;
+    font-size: .85em;
+    font-weight: 700;
+    line-height: 1;
+    padding: 2px 4px;
+    white-space: nowrap;
+}


### PR DESCRIPTION
Fixes #81 
@thibaudcolas I have added the inline style for keyboard inputs. I am attaching the screenshots of the final result. I have copied the css from https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd. Let me know if the css is to be changed.
<img width="949" alt="image" src="https://user-images.githubusercontent.com/76250591/196021791-22b20f4b-9df7-4621-ab0a-1d0edd1f2ed9.png">
<img width="810" alt="image" src="https://user-images.githubusercontent.com/76250591/196021822-488e9ac3-5f8e-4359-bd6e-3a9011adb552.png">
