### PR TITLE
Rework caching-worker to align with Eslint usage

### DIFF
--- a/cloudflare/caching-worker.js
+++ b/cloudflare/caching-worker.js
@@ -31,15 +31,142 @@ const STRIP_VALUELESS_QUERYSTRING_KEYS = true;
 // (from https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.4)
 const CACHABLE_HTTP_STATUS_CODES = [200, 203, 206, 300, 301, 410];
 
-addEventListener('fetch', (event) => {
-    event.respondWith(main(event));
-});
+/*
+ * Request Utilities
+ */
+function stripQuerystring(request) {
+    /**
+     * Given a Request, return a new Request with the ignored or blank querystring keys stripped out,
+     * along with an object representing the stripped values.
+     */
+    const url = new URL(request.url);
+
+    const stripKeys = STRIP_QUERYSTRING_KEYS.filter((v) =>
+        url.searchParams.has(v),
+    );
+
+    const strippedParams = {};
+
+    if (stripKeys.length) {
+        stripKeys.reduce((acc, key) => {
+            acc[key] = url.searchParams.getAll(key);
+            url.searchParams.delete(key);
+            return acc;
+        }, strippedParams);
+    }
+
+    if (STRIP_VALUELESS_QUERYSTRING_KEYS) {
+        // Strip query params without values to avoid unnecessary cache misses
+        url.searchParams.entries().forEach(([key, value]) => {
+            if (!value) {
+                url.searchParams.delete(key);
+                strippedParams[key] = '';
+            }
+        });
+    }
+
+    return [new Request(url, request), strippedParams];
+}
+
+/**
+ * URL Utilities
+ */
+function isUrlAbsolute(url) {
+    return url.indexOf('://') > 0 || url.indexOf('//') === 0;
+}
+
+function hasPrivateCookie(request) {
+    /*
+     * Given a Request, determine if one of the 'private' cookies are present.
+     */
+    const cookieHeader = request.headers.get('Cookie');
+    if (!cookieHeader) {
+        return false;
+    }
+
+    const requestCookieNames = cookieHeader
+        .split(';')
+        .map((cookie) => cookie.split('=')[0].trim());
+
+    return PRIVATE_COOKIES.some((privateCookieName) =>
+        requestCookieNames.includes(privateCookieName),
+    );
+}
+
+/*
+ * Cacheability Utilities
+ */
+function requestIsCachable(request) {
+    /*
+     * Given a Request, determine if it should be cached.
+     * Currently the only factor here is whether a private cookie is present.
+     */
+    return !hasPrivateCookie(request);
+}
+
+function responseIsCachable(response) {
+    /*
+     * Given a Response, determine if it should be cached.
+     * Currently the only factor here is whether the status code is cachable.
+     */
+    return CACHABLE_HTTP_STATUS_CODES.includes(response.status);
+}
+
+/**
+ * Response Utilities
+ */
+
+function replaceStrippedQsOnRedirectResponse(originalResponse, strippedParams) {
+    /**
+     * Given an existing Response, and an object of stripped querystring keys,
+     * determine if the response is a redirect.
+     * If it is, add the stripped querystrings to the location header.
+     * This allows us to persist tracking querystrings (like UTM) over redirects.
+     */
+    const response = new Response(originalResponse.body, originalResponse);
+
+    if ([301, 302].includes(response.status)) {
+        const locationHeaderValue = response.headers.get('location');
+        let locationUrl;
+
+        if (!locationHeaderValue) {
+            return response;
+        }
+
+        const isAbsolute = isUrlAbsolute(locationHeaderValue);
+
+        if (!isAbsolute) {
+            // If the Location URL isn't absolute, we need to provide a Host so we can use
+            // a URL object.
+            locationUrl = new URL(
+                locationHeaderValue,
+                'http://www.example.com',
+            );
+        } else {
+            locationUrl = new URL(locationHeaderValue);
+        }
+
+        Object.entries(strippedParams).forEach(([key, value]) => {
+            locationUrl.searchParams.append(key, value);
+        });
+
+        let newLocation;
+
+        if (isAbsolute) {
+            newLocation = locationUrl.toString();
+        } else {
+            newLocation = `${locationUrl.pathname}${locationUrl.search}`;
+        }
+
+        response.headers.set('location', newLocation);
+    }
+
+    return response;
+}
 
 async function main(event) {
     const cache = caches.default;
-    let request = event.request;
-    let strippedParams;
-    [request, strippedParams] = stripQuerystring(request);
+    const [request, strippedParams] = stripQuerystring(event.request);
 
     if (!requestIsCachable(request)) {
         // If the request isn't cacheable, return a Response directly from the origin.
@@ -67,135 +194,6 @@ async function main(event) {
     return response;
 }
 
-/*
- * Cacheability Utilities
- */
-function requestIsCachable(request) {
-    /*
-     * Given a Request, determine if it should be cached.
-     * Currently the only factor here is whether a private cookie is present.
-     */
-    return !hasPrivateCookie(request);
-}
-
-function responseIsCachable(response) {
-    /*
-     * Given a Response, determine if it should be cached.
-     * Currently the only factor here is whether the status code is cachable.
-     */
-    return CACHABLE_HTTP_STATUS_CODES.includes(response.status);
-}
-
-/*
- * Request Utilities
- */
-function stripQuerystring(request) {
-    /**
-     * Given a Request, return a new Request with the ignored or blank querystring keys stripped out,
-     * along with an object representing the stripped values.
-     */
-    const url = new URL(request.url);
-
-    const stripKeys = STRIP_QUERYSTRING_KEYS.filter((v) =>
-        url.searchParams.has(v),
-    );
-
-    let strippedParams = {};
-
-    if (stripKeys.length) {
-        stripKeys.reduce((acc, key) => {
-            acc[key] = url.searchParams.getAll(key);
-            url.searchParams.delete(key);
-            return acc;
-        }, strippedParams);
-    }
-
-    if (STRIP_VALUELESS_QUERYSTRING_KEYS) {
-        // Strip query params without values to avoid unnecessary cache misses
-        for (const [key, value] of url.searchParams.entries()) {
-            if (!value) {
-                url.searchParams.delete(key);
-                strippedParams[key] = '';
-            }
-        }
-    }
-
-    return [new Request(url, request), strippedParams];
-}
-
-function hasPrivateCookie(request) {
-    /*
-     * Given a Request, determine if one of the 'private' cookies are present.
-     */
-    const cookieHeader = request.headers.get('Cookie');
-    if (!cookieHeader) {
-        return false;
-    }
-
-    const requestCookieNames = cookieHeader
-        .split(';')
-        .map((cookie) => cookie.split('=')[0].trim());
-
-    return PRIVATE_COOKIES.some((privateCookieName) =>
-        requestCookieNames.includes(privateCookieName),
-    );
-}
-
-/**
- * Response Utilities
- */
-
-function replaceStrippedQsOnRedirectResponse(response, strippedParams) {
-    /**
-     * Given an existing Response, and an object of stripped querystring keys,
-     * determine if the response is a redirect.
-     * If it is, add the stripped querystrings to the location header.
-     * This allows us to persist tracking querystrings (like UTM) over redirects.
-     */
-    response = new Response(response.body, response);
-
-    if ([301, 302].includes(response.status)) {
-        const locationHeaderValue = response.headers.get('location');
-        let locationUrl;
-
-        if (!locationHeaderValue) {
-            return response;
-        }
-
-        const isAbsolute = isUrlAbsolute(locationHeaderValue);
-
-        if (!isAbsolute) {
-            // If the Location URL isn't absolute, we need to provide a Host so we can use
-            // a URL object.
-            locationUrl = new URL(
-                locationHeaderValue,
-                'http://www.example.com',
-            );
-        } else {
-            locationUrl = new URL(locationHeaderValue);
-        }
-
-        for (const [key, value] of Object.entries(strippedParams)) {
-            locationUrl.searchParams.append(key, value);
-        }
-
-        let newLocation;
-
-        if (isAbsolute) {
-            newLocation = locationUrl.toString();
-        } else {
-            newLocation = `${locationUrl.pathname}${locationUrl.search}`;
-        }
-
-        response.headers.set('location', newLocation);
-    }
-
-    return response;
-}
-
-/**
- * URL Utilities
- */
-function isUrlAbsolute(url) {
-    return url.indexOf('://') > 0 || url.indexOf('//') === 0;
-}
+window.addEventListener('fetch', (event) => {
+    event.respondWith(main(event));
+});


### PR DESCRIPTION
* Adopts linting for JS file introduced in https://github.com/wagtail/guide/pull/165
* Note: We could also just add this file to the eslintignore if it is not meant to align with our linting styleguide