### PR TITLE
Add shadow to images, prevent bleeding. Fix #166

### DIFF
--- a/apps/frontend/static_src/scss/components/alert.scss
+++ b/apps/frontend/static_src/scss/components/alert.scss
@@ -1,6 +1,6 @@
 .alert {
     $root: &;
-    box-shadow: 0 2px 4px 0 rgba($color--black, 0.2);
+    box-shadow: 2px 2px 8px 0 rgba($color--black, 0.3);
     border-radius: $border-radius--m;
     margin-bottom: ($gutter * 3);
     overflow: hidden;

--- a/apps/frontend/static_src/scss/components/rich-text-image.scss
+++ b/apps/frontend/static_src/scss/components/rich-text-image.scss
@@ -1,4 +1,7 @@
 .richtext-image {
+    box-shadow: 2px 2px 8px 0 rgba($color--black, 0.3);
+    border-radius: $border-radius--m;
+
     &.full-width {
         display: block;
         width: 100%;


### PR DESCRIPTION
Closes #166

<img width="1912" alt="Screenshot 2022-10-24 at 21 08 14" src="https://user-images.githubusercontent.com/1969342/197606092-6e022e0b-6d66-4a44-9ff0-d889722f6e62.png">
<img width="1912" alt="Screenshot 2022-10-24 at 21 08 08" src="https://user-images.githubusercontent.com/1969342/197606111-dc973a4a-cb9a-475c-bef5-402cca783e6f.png">
