### PR TITLE
Add `fnm` details to README & reference nvmrc file for Node version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version-file: '.nvmrc'
       - name: Install Poetry
         run: curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.2.2 python -
       - name: Install Python dependencies

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ You can learn more about the documentation system [here](https://documentation.d
 
 # Installation
 
-We assume that you have basic knowledge of Node/Yarn/Webpack and Python/Django/Wagtail in these instructions. We recommend you develop Wagtail Guide locally on your machine using venv.
+We assume that you have basic knowledge of Node/Yarn/Webpack and Python/Django/Wagtail in these instructions. We recommend you develop Wagtail Guide locally on your machine using `venv` and [fnm](https://github.com/Schniz/fnm) to ensure you are on the correct Node version.
 
 #### Dependencies
 
+-   Git
 -   Python >= 3.9
 -   Poetry >= 1.2.2
--   Git
--   Node 16.\*
+-   Node (see `.nvmrc` for version)
 -   [Yarn](https://yarnpkg.com/)
 
 ### Setting up Wagtail guide in a virtual environment


### PR DESCRIPTION
- Fixes #151 - this is the final original todo item of that issue.
- Avoid hard-coding Node version where possible and instead reference the nvmrc file, including the Github action - https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file
- Also moves git to the top of the list of dependencies
- Note: All other items on https://github.com/wagtail/guide/issues/151 will be split to new issues.