### PR TITLE
Prevent left column scrolling 20px before sticking

### DIFF
--- a/apps/frontend/static_src/scss/components/header.scss
+++ b/apps/frontend/static_src/scss/components/header.scss
@@ -3,7 +3,7 @@
 
     @include media-query(large) {
         position: sticky;
-        top: ($gutter * 1.5);
+        top: ($gutter * 2.5);
         margin-top: ($gutter * 2.5);
     }
 


### PR DESCRIPTION
Small fix to prevent the left column scrolling 20px before sticking on large viewports