### PR TITLE
Fix html `lang` attribute and generate `hreflang` links to translations

### DIFF
--- a/apps/core/templates/base.html
+++ b/apps/core/templates/base.html
@@ -27,10 +27,8 @@
         <link rel="icon" type="image/png" sizes="32x32" href="{% manifest 'images/favicon-32x32.png' %}">
         <link rel="icon" type="image/png" sizes="16x16" href="{% manifest 'images/favicon-16x16.png' %}">
 
-        {# alternate tag #}
-        {% if page.locale.language_code and not page.locale.language_code == "en-latest" %}
-            <link rel="alternate" hreflang="en" href="{{ page.full_url|hreflang_url:page.locale.language_code }}" >
-        {% endif %}
+        {# alternate tags #}
+        {% hreflangs %}
 
         {% comment %}
             Twitter summary card - see https://dev.twitter.com/cards/types/summary

--- a/apps/core/templates/base.html
+++ b/apps/core/templates/base.html
@@ -2,7 +2,7 @@
 
 {% wagtail_site as current_site %}
 <!DOCTYPE html>
-<html lang="{% block lang %}{{ self.locale.language_code }}{% endblock %}" class="no-js">
+<html lang="{% block lang %}{% get_language_from_language_code self.locale.language_code %}{% endblock %}" class="no-js">
     <head>
         <meta charset="utf-8" />
         <title>

--- a/apps/core/templates/components/hreflangs.html
+++ b/apps/core/templates/components/hreflangs.html
@@ -1,0 +1,3 @@
+{% for locale, href in translations %}
+    <link rel="alternate" hreflang="{{ locale }}" href="{{ href }}">
+{% endfor %}

--- a/apps/core/templates/components/language_selector.html
+++ b/apps/core/templates/components/language_selector.html
@@ -12,7 +12,7 @@
             {% for translation in page.get_translations.live %}
                 {% get_language_info for translation.locale.language_code as lang %}
                 <li>
-                    <a href="{% pageurl translation %}" rel="alternate" hreflang="{{ language_code }}" class="language-selector__dropdown-item dropdown-item">
+                    <a href="{% pageurl translation %}" rel="alternate" hreflang="{% get_language_from_language_code translation.locale.language_code %}" class="language-selector__dropdown-item dropdown-item">
                         {{ lang.name_local }} ({% get_version_from_language_code translation.locale.language_code %})
                     </a>
                 </li>

--- a/apps/core/templatetags/core_tags.py
+++ b/apps/core/templatetags/core_tags.py
@@ -30,3 +30,8 @@ def hreflang_url(value, arg):
 @register.simple_tag
 def get_version_from_language_code(language_code):
     return language_code.rsplit("-", maxsplit=1)[1]
+
+
+@register.simple_tag
+def get_language_from_language_code(language_code):
+    return language_code.rsplit("-", maxsplit=1)[0]

--- a/apps/core/tests/test_alternate_link_tag.py
+++ b/apps/core/tests/test_alternate_link_tag.py
@@ -1,38 +1,83 @@
-import json
-
 from django.test import TestCase
 
 from apps.core.factories import ContentPageFactory, HomePageFactory, LocaleFactory
 
 
-class TestAlternateLinkTag(TestCase):
+class TestAlternateLinkTagsHomePage(TestCase):
     def setUp(self):
-        self.en = LocaleFactory(language_code="en-latest")
-        self.home_page_en = HomePageFactory(locale=self.en)
-        self.nl = LocaleFactory(language_code="nl-4.1.x")
-        self.home_page_nl = self.home_page_en.copy_for_translation(self.nl)
-        self.home_page_nl.save_revision().publish()
-        body = json.dumps(
-            [
-                {"type": "text", "value": "<p>some test content</p>"},
-            ],
+        self.en_latest = LocaleFactory(language_code="en-latest")
+        self.en_41x = LocaleFactory(language_code="en-4.1.x")
+        self.nl_41x = LocaleFactory(language_code="nl-4.1.x")
+        self.is_41x = LocaleFactory(language_code="is-4.1.x")
+
+        self.page_en_latest = HomePageFactory(locale=self.en_latest)
+        self.page_en_41x = self.page_en_latest.copy_for_translation(self.en_41x)
+        self.page_en_41x.save_revision().publish()
+        self.page_nl_41x = self.page_en_latest.copy_for_translation(self.nl_41x)
+        self.page_nl_41x.save_revision().publish()
+        self.page_is_41x = self.page_en_latest.copy_for_translation(self.is_41x)
+        self.page_is_41x.save_revision().publish()
+
+    def test_en_latest_no_alternate_tags(self):
+        response = self.client.get(self.page_en_latest.full_url)
+        # Should not have the alternate tags
+        # as there are no translations for the latest version
+        self.assertNotContains(response, '<link rel="alternate"')
+
+    def test_en_41x_alternate_tags(self):
+        response = self.client.get(self.page_en_41x.full_url)
+        # Should have the alternate tag for the
+        # Dutch 4.1.x and Icelandic 4.1.x versions only
+        href = self.page_nl_41x.full_url
+        self.assertContains(
+            response,
+            f'<link rel="alternate" hreflang="nl" href="{href}">',
         )
-        self.content_page_en = ContentPageFactory(body=body, locale=self.en)
-        self.content_page_nl = self.content_page_en.copy_for_translation(self.nl)
-        self.content_page_nl.save_revision().publish()
+        href = self.page_is_41x.full_url
+        self.assertContains(
+            response,
+            f'<link rel="alternate" hreflang="is" href="{href}">',
+        )
 
-    def test_home_page_nl_has_alternate_tag(self):
-        response = self.client.get(self.home_page_nl.url)
-        self.assertContains(response, '<link rel="alternate" hreflang="en"')
+        # Should not have the alternate tag for the English latest version
+        href = self.page_en_latest.full_url
+        self.assertNotContains(
+            response,
+            f'<link rel="alternate" hreflang="en" href="{href}">',
+        )
+        self.assertContains(response, '<link rel="alternate"', count=2)
 
-    def test_content_page_nl_has_alternate_tag(self):
-        response = self.client.get(self.content_page_nl.url)
-        self.assertContains(response, '<link rel="alternate" hreflang="en"')
+    def test_nl_41x_alternate_tags(self):
+        response = self.client.get(self.page_nl_41x.full_url)
+        # Should have the alternate tag for the
+        # English 4.1.x and Icelandic 4.1.x versions only
+        href = self.page_en_41x.full_url
+        self.assertContains(
+            response,
+            f'<link rel="alternate" hreflang="en" href="{href}">',
+        )
+        href = self.page_is_41x.full_url
+        self.assertContains(
+            response,
+            f'<link rel="alternate" hreflang="is" href="{href}">',
+        )
 
-    def test_home_page_en_has_no_alternate_tag(self):
-        response = self.client.get(self.home_page_en.url)
-        self.assertNotContains(response, '<link rel="alternate" hreflang="en"')
+        # Should not have the alternate tag for the English latest version
+        href = self.page_en_latest.full_url
+        self.assertNotContains(
+            response,
+            f'<link rel="alternate" hreflang="en" href="{href}">',
+        )
+        self.assertContains(response, '<link rel="alternate"', count=2)
 
-    def test_content_page_en_has_no_alternate_tag(self):
-        response = self.client.get(self.content_page_en.url)
-        self.assertNotContains(response, '<link rel="alternate" hreflang="en"')
+
+class TestAlternateLinkTagsContentPage(TestAlternateLinkTagsHomePage):
+    def setUp(self):
+        super().setUp()
+        self.page_en_latest = ContentPageFactory(locale=self.en_latest)
+        self.page_en_41x = self.page_en_latest.copy_for_translation(self.en_41x)
+        self.page_en_41x.save_revision().publish()
+        self.page_nl_41x = self.page_en_latest.copy_for_translation(self.nl_41x)
+        self.page_nl_41x.save_revision().publish()
+        self.page_is_41x = self.page_en_latest.copy_for_translation(self.is_41x)
+        self.page_is_41x.save_revision().publish()


### PR DESCRIPTION
Fixes #194 and #195.

Needs tests.