### PR TITLE
Use original id when generating links in table of contents

### DIFF
--- a/apps/core/models/content.py
+++ b/apps/core/models/content.py
@@ -4,7 +4,7 @@ from bs4 import BeautifulSoup
 from django.db import models
 from django.http import HttpResponse
 from django.template import Context, Template
-from django.template.defaultfilters import slugify
+from django.utils.text import slugify
 from wagtail.admin.panels import FieldPanel
 from wagtail.core.fields import StreamField
 from wagtail.models import Page
@@ -23,7 +23,8 @@ def create_table_of_contents(body):
     if headings:
         toc += "<ul>"
         for heading in headings:
-            toc += f'<li><a href="#{slugify(heading.text)}">{heading.text}</a></li>'  # noqa
+            anchor = heading.attrs.get("id", slugify(heading.text))
+            toc += f'<li><a href="#{anchor}">{heading.text}</a></li>'
         toc += "</ul>"
     return toc
 

--- a/apps/core/tests/test_content_page.py
+++ b/apps/core/tests/test_content_page.py
@@ -7,11 +7,27 @@ class TestContentPage(TestCase):
     def setUp(self):
         self.content_page = ContentPageFactory()
 
-    def test_create_table_of_contents(self):
+    def test_create_table_of_contents_no_id(self):
+        # If there's no id, generate it by slugifying the text.
         assert self.content_page.table_of_contents == ""
-        self.content_page.body = '[{"type": "text", "value": "<h2>ekkie</h2>"}]'
+        self.content_page.body = '[{"type": "text", "value": "<h2>Foo bar</h2>"}]'
         self.content_page.save_revision()
         assert (
             self.content_page.table_of_contents
-            == '<ul><li><a href="#ekkie">ekkie</a></li></ul>'
+            == '<ul><li><a href="#foo-bar">Foo bar</a></li></ul>'
+        )
+
+    def test_create_table_of_contents_existing_id(self):
+        # Our custom AnchorBlockConverter for Draft.js isn't called when
+        # translating with wagtail-localize, so the id isn't updated.
+        # If there's an existing id, make sure to use that instead so the link
+        # still works.
+        assert self.content_page.table_of_contents == ""
+        self.content_page.body = (
+            '[{"type": "text", "value": "<h2 id=\\"something\\">ekkie</h2>"}]'
+        )
+        self.content_page.save_revision()
+        assert (
+            self.content_page.table_of_contents
+            == '<ul><li><a href="#something">ekkie</a></li></ul>'
         )


### PR DESCRIPTION
Fixes #182.

I spent some time digging into this, looks like wagtail-localize completely skips over custom rich text features we added here:

https://github.com/wagtail/guide/blob/60cb0bb278e1a295b295734acb51d0e0ba7ded00/apps/richtext/wagtail_hooks.py#L7-L41

I haven't found a way to fix this properly, as it seems that it's just how wagtail-localize works, i.e. it separates out the HTML stuff from user-facing strings.

This PR adds a workaround by using the existing id (in the original language) so that links will still work (though the anchor slug will be in the original language, e.g. English).

This issue only happens with synced translations. Unsynced translations work normally.

~~I'll try to add tests tomorrow.~~ Added.