### PR TITLE
Fix home page crash when translation cannot be found

### DIFF
--- a/apps/core/templatetags/core_tags.py
+++ b/apps/core/templatetags/core_tags.py
@@ -10,6 +10,11 @@ register = template.Library()
 @register.inclusion_tag("components/header.html", takes_context=True)
 def header(context):
     home = HomePage.objects.filter(locale__language_code=get_language()).first()
+
+    # Translation may not have been activated (e.g. accessing the root path)
+    if not home:
+        home = HomePage.objects.first()
+
     pages = (
         Page.objects.descendant_of(home)
         .filter(depth__gt=2, depth__lte=4)


### PR DESCRIPTION
Fixes https://sentry.io/organizations/wagtail-org/issues/3699443518/?project=4504043711037440

Honestly don't know why this happens as Django's `get_language()` function should fall back to `settings.LANGUAGE_CODE`, and I thought we could assume the `HomePage` with the default `LANGUAGE_CODE` (i.e. `en-latest`) exists. Not sure how to test it either as this doesn't seem to happen locally. I'll add another PR if I find a way to test this.