### PR TITLE
Translate apps only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,15 @@ backend:
 run:
 	poetry run python manage.py runserver
 
-translations:
-	poetry run python manage.py makemessages --all
-	poetry run python manage.py makemessages --all -e ".js" -d djangojs --ignore=apps/frontend/static/* --ignore=node_modules/* --ignore=static/*
-	poetry run python manage.py compilemessages
+
+translations: makemessages compilemessages
+
+makemessages:
+	cd apps && poetry run python ../manage.py makemessages --all --no-location
+	cd apps && poetry run python ../manage.py makemessages --all --no-location -e ".js" -d djangojs --ignore=frontend/static/*
+
+compilemessages:
+	cd apps && poetry run python ../manage.py compilemessages
 
 docker-build:
 	docker build -t guide:latest --build-arg POETRY_INSTALL_ARGS="" -f Dockerfile .

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ To activate Poetry's virtual environment, run:
 
 To generate and compile translation strings, run:
 
+    make makemessages
+    make compilemessages
+
+Or both, in a single command:
+
     make translations
 
 ### Setting up development with Docker

--- a/locale/af/LC_MESSAGES/django.po
+++ b/locale/af/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/af/LC_MESSAGES/djangojs.po
+++ b/locale/af/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,135 +19,101 @@ msgstr ""
 "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
 "&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/ar/LC_MESSAGES/djangojs.po
+++ b/locale/ar/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,11 +19,9 @@ msgstr ""
 "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
 "&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/az/LC_MESSAGES/django.po
+++ b/locale/az/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/az/LC_MESSAGES/djangojs.po
+++ b/locale/az/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/be/LC_MESSAGES/django.po
+++ b/locale/be/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,139 +16,105 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
-"%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
+"(n%100>=11 && n%100<=14)? 2 : 3);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/be/LC_MESSAGES/djangojs.po
+++ b/locale/be/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,15 +16,13 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
-"%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
+"(n%100>=11 && n%100<=14)? 2 : 3);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/bg/LC_MESSAGES/django.po
+++ b/locale/bg/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/bg/LC_MESSAGES/djangojs.po
+++ b/locale/bg/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/bn/LC_MESSAGES/django.po
+++ b/locale/bn/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/bn/LC_MESSAGES/djangojs.po
+++ b/locale/bn/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/ca/LC_MESSAGES/django.po
+++ b/locale/ca/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/ca/LC_MESSAGES/djangojs.po
+++ b/locale/ca/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/cs/LC_MESSAGES/django.po
+++ b/locale/cs/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,135 +19,101 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n "
 "<= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/cs/LC_MESSAGES/djangojs.po
+++ b/locale/cs/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,11 +19,9 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n "
 "<= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,135 +19,101 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != "
 "11) ? 2 : 3;\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/cy/LC_MESSAGES/djangojs.po
+++ b/locale/cy/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,11 +19,9 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != "
 "11) ? 2 : 3;\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/da/LC_MESSAGES/django.po
+++ b/locale/da/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/da/LC_MESSAGES/djangojs.po
+++ b/locale/da/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/de/LC_MESSAGES/djangojs.po
+++ b/locale/de/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/el/LC_MESSAGES/django.po
+++ b/locale/el/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/el/LC_MESSAGES/djangojs.po
+++ b/locale/el/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/en/LC_MESSAGES/djangojs.po
+++ b/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/es/LC_MESSAGES/djangojs.po
+++ b/locale/es/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/et/LC_MESSAGES/django.po
+++ b/locale/et/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/et/LC_MESSAGES/djangojs.po
+++ b/locale/et/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/eu/LC_MESSAGES/django.po
+++ b/locale/eu/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/eu/LC_MESSAGES/djangojs.po
+++ b/locale/eu/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/fa/LC_MESSAGES/djangojs.po
+++ b/locale/fa/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/fi/LC_MESSAGES/djangojs.po
+++ b/locale/fi/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/fr/LC_MESSAGES/djangojs.po
+++ b/locale/fr/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/gl/LC_MESSAGES/django.po
+++ b/locale/gl/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/gl/LC_MESSAGES/djangojs.po
+++ b/locale/gl/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/he/LC_MESSAGES/django.po
+++ b/locale/he/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,135 +19,101 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % "
 "1 == 0) ? 1: (n % 10 == 0 && n % 1 == 0 && n > 10) ? 2 : 3;\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/he/LC_MESSAGES/djangojs.po
+++ b/locale/he/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,11 +19,9 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % "
 "1 == 0) ? 1: (n % 10 == 0 && n % 1 == 0 && n > 10) ? 2 : 3;\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/hr/LC_MESSAGES/django.po
+++ b/locale/hr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,138 +16,104 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/hr/LC_MESSAGES/djangojs.po
+++ b/locale/hr/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,14 +16,12 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/hu/LC_MESSAGES/djangojs.po
+++ b/locale/hu/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/hy/LC_MESSAGES/django.po
+++ b/locale/hy/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/hy/LC_MESSAGES/djangojs.po
+++ b/locale/hy/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/id/LC_MESSAGES/django.po
+++ b/locale/id/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/id/LC_MESSAGES/djangojs.po
+++ b/locale/id/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/is/LC_MESSAGES/django.po
+++ b/locale/is/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n % 10 != 1 || n % 100 == 11);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr "Viðvörun"
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr "Athugasemd"
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr "Síða fannst ekki"
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr "Því miður fannst ekkert á þessari vefslóð."
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr "Hjálpaði þessi síða þér?"
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr "Þessi síða hjálpaði mér"
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr "Glaður broskall"
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr "Það er hægt að bæta úr þessari síðu"
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr "Leiður broskall"
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr "Hjálpaðu okkur að bæta úr efninu með því að segja okkur hvað vantar"
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr "Þitt álit"
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr "Senda"
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr "Handbókin"
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr "Sýna leitarform"
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr "Kveikja á valmynd fyrir snjalltæki"
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr "Leita"
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr "Fara beint í meginmál"
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr "Á þessari síðu"
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr "Fyrri"
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr "Næsta"
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr "Engar síður fundust"
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr "Heim"

--- a/locale/is/LC_MESSAGES/djangojs.po
+++ b/locale/is/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n % 10 != 1 || n % 100 == 11);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr "Takk fyrir að gefa þitt álit!"
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/it/LC_MESSAGES/djangojs.po
+++ b/locale/it/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/ja/LC_MESSAGES/djangojs.po
+++ b/locale/ja/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/ka/LC_MESSAGES/django.po
+++ b/locale/ka/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/ka/LC_MESSAGES/djangojs.po
+++ b/locale/ka/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/ko/LC_MESSAGES/django.po
+++ b/locale/ko/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/ko/LC_MESSAGES/djangojs.po
+++ b/locale/ko/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/lt/LC_MESSAGES/django.po
+++ b/locale/lt/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,135 +20,101 @@ msgstr ""
 "11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? "
 "1 : n % 1 != 0 ? 2: 3);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/lt/LC_MESSAGES/djangojs.po
+++ b/locale/lt/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,11 +20,9 @@ msgstr ""
 "11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? "
 "1 : n % 1 != 0 ? 2: 3);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/lv/LC_MESSAGES/django.po
+++ b/locale/lv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,135 +19,101 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
 "2);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/lv/LC_MESSAGES/djangojs.po
+++ b/locale/lv/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,11 +19,9 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
 "2);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/mn/LC_MESSAGES/django.po
+++ b/locale/mn/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/mn/LC_MESSAGES/djangojs.po
+++ b/locale/mn/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/my/LC_MESSAGES/django.po
+++ b/locale/my/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/my/LC_MESSAGES/djangojs.po
+++ b/locale/my/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/nb/LC_MESSAGES/django.po
+++ b/locale/nb/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/nb/LC_MESSAGES/djangojs.po
+++ b/locale/nb/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/nl/LC_MESSAGES/djangojs.po
+++ b/locale/nl/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,139 +16,105 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n"
-"%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n"
-"%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && "
+"(n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && "
+"n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/pl/LC_MESSAGES/djangojs.po
+++ b/locale/pl/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,15 +16,13 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n"
-"%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n"
-"%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && "
+"(n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && "
+"n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/pt/LC_MESSAGES/djangojs.po
+++ b/locale/pt/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/pt_br/LC_MESSAGES/django.po
+++ b/locale/pt_br/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/pt_br/LC_MESSAGES/djangojs.po
+++ b/locale/pt_br/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,135 +19,101 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
 "2:1));\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/ro/LC_MESSAGES/djangojs.po
+++ b/locale/ro/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,11 +19,9 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
 "2:1));\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,139 +16,105 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
-"%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
+"(n%100>=11 && n%100<=14)? 2 : 3);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/ru/LC_MESSAGES/djangojs.po
+++ b/locale/ru/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,15 +16,13 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
-"%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
+"(n%100>=11 && n%100<=14)? 2 : 3);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/sk/LC_MESSAGES/django.po
+++ b/locale/sk/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,135 +19,101 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n == 1 ? 0 : n % 1 == 0 && n "
 ">= 2 && n <= 4 ? 1 : n % 1 != 0 ? 2: 3);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/sk/LC_MESSAGES/djangojs.po
+++ b/locale/sk/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,11 +19,9 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n == 1 ? 0 : n % 1 == 0 && n "
 ">= 2 && n <= 4 ? 1 : n % 1 != 0 ? 2: 3);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/sl/LC_MESSAGES/django.po
+++ b/locale/sl/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,138 +16,104 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
-"%100==4 ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/sl/LC_MESSAGES/djangojs.po
+++ b/locale/sl/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,14 +16,12 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
-"%100==4 ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/sr/LC_MESSAGES/django.po
+++ b/locale/sr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,138 +16,104 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/sr/LC_MESSAGES/djangojs.po
+++ b/locale/sr/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,14 +16,12 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/sv/LC_MESSAGES/djangojs.po
+++ b/locale/sv/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/ta/LC_MESSAGES/django.po
+++ b/locale/ta/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/ta/LC_MESSAGES/djangojs.po
+++ b/locale/ta/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/th/LC_MESSAGES/django.po
+++ b/locale/th/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/th/LC_MESSAGES/djangojs.po
+++ b/locale/th/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/tr/LC_MESSAGES/djangojs.po
+++ b/locale/tr/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/uk/LC_MESSAGES/django.po
+++ b/locale/uk/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,135 +21,101 @@ msgstr ""
 "100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || "
 "(n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/uk/LC_MESSAGES/djangojs.po
+++ b/locale/uk/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,11 +21,9 @@ msgstr ""
 "100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || "
 "(n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/vi/LC_MESSAGES/djangojs.po
+++ b/locale/vi/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/zh_hans/LC_MESSAGES/django.po
+++ b/locale/zh_hans/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/zh_hans/LC_MESSAGES/djangojs.po
+++ b/locale/zh_hans/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."

--- a/locale/zh_hant/LC_MESSAGES/django.po
+++ b/locale/zh_hant/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:30+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,135 +18,101 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: apps/core/blocks.py:19
 msgid "Tutorial"
 msgstr ""
 
-#: apps/core/blocks.py:20
 msgid "How-to"
 msgstr ""
 
-#: apps/core/blocks.py:21
 msgid "Reference"
 msgstr ""
 
-#: apps/core/blocks.py:22
 msgid "Explanation"
 msgstr ""
 
-#: apps/core/blocks.py:24 apps/core/blocks.py:37
 msgid "Section"
 msgstr ""
 
-#: apps/core/blocks.py:26
 msgid "Title"
 msgstr ""
 
-#: apps/core/blocks.py:27
 msgid "Text"
 msgstr ""
 
-#: apps/core/blocks.py:28
 msgid "Page"
 msgstr ""
 
-#: apps/core/blocks.py:41
 msgid "Section grid"
 msgstr ""
 
-#: apps/core/blocks.py:54
 msgid "Warning"
 msgstr ""
 
-#: apps/core/blocks.py:55
 msgid "Note"
 msgstr ""
 
-#: apps/core/templates/404.html:4 apps/core/templates/404.html:8
 msgid "Page not found"
 msgstr ""
 
-#: apps/core/templates/404.html:10
 msgid "Sorry, this page could not be found."
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:5
 msgid "Was this page helpful?"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "This page was helpful"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:7
 msgid "Happy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "This page could be improved"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:10
 msgid "Unhappy"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:18
 msgid "Help us improve by telling what you missed"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:19
 msgid "Your feedback"
 msgstr ""
 
-#: apps/core/templates/components/feedback.html:21
 msgid "Submit"
 msgstr ""
 
-#: apps/core/templates/components/header.html:18
 msgid "User guide"
 msgstr ""
 
-#: apps/core/templates/components/header.html:19
 msgid "Toggle the search form"
 msgstr ""
 
-#: apps/core/templates/components/header.html:24
 msgid "Mobile menu toggle"
 msgstr ""
 
-#: apps/core/templates/components/search_modal.html:8
-#: apps/core/templates/components/search_modal.html:9
-#: apps/core/templates/components/search_modal.html:10
-#: apps/search/templates/search/search.html:4
-#: apps/search/templates/search/search.html:7
-#: apps/search/templates/search/search.html:13
 msgid "Search"
 msgstr ""
 
-#: apps/core/templates/components/skip_link.html:4
 msgid "Skip to main content"
 msgstr ""
 
-#: apps/core/templates/core/content_page.html:10
+msgid "JavaScript is required to toggle light/dark mode."
+msgstr ""
+
 msgid "On this page"
 msgstr ""
 
-#: apps/custom_media/models.py:18
 msgid "image"
 msgstr ""
 
-#: apps/search/templates/search/search.html:30
 msgid "Previous"
 msgstr ""
 
-#: apps/search/templates/search/search.html:34
 msgid "Next"
 msgstr ""
 
-#: apps/search/templates/search/search.html:37
 msgid "No results found"
 msgstr ""
 
-#: apps/search/views.py:58
 msgid "Home"
 msgstr ""

--- a/locale/zh_hant/LC_MESSAGES/djangojs.po
+++ b/locale/zh_hant/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-31 20:32+0000\n"
+"POT-Creation-Date: 2022-11-04 23:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: apps/frontend/static_src/js/feedback/index.js:65
 msgid "Thanks for your feedback!"
 msgstr ""
 
-#: apps/frontend/static_src/js/main.js:28
 #, javascript-format
 msgid "%s result found."
 msgid_plural "%s results found."


### PR DESCRIPTION
This PR makes the `make translations` command cd into the apps folder to translate only our strings.
It also drops the file locations (comments with line numbers) from the po files to avoid git conflicts.
