### PR TITLE
Fix dropdown item hover bgcolor in dark mode

### DIFF
--- a/apps/frontend/static_src/scss/components/language-selector.scss
+++ b/apps/frontend/static_src/scss/components/language-selector.scss
@@ -49,5 +49,11 @@
             background-color: $color--black;
             color: $color--light-grey;
         }
+        #{$root}__dropdown-item {
+            &:hover,
+            &:focus {
+                background-color: $color--grey;
+            }
+        }
     }
 }


### PR DESCRIPTION
# Before

<img width="898" alt="Screenshot 2022-11-05 at 02 08 19" src="https://user-images.githubusercontent.com/1969342/200094352-034d4883-2f7e-42d7-b139-aab9e8e30159.png">

# After

<img width="898" alt="Screenshot 2022-11-05 at 02 08 40" src="https://user-images.githubusercontent.com/1969342/200094359-c5921c35-88a0-4f43-a1a1-6d81319465b2.png">
