### PR TITLE
Remove language selector when we don't have a page to show versions of.

### DIFF
--- a/apps/core/middleware.py
+++ b/apps/core/middleware.py
@@ -12,7 +12,7 @@ class ValidateLocaleMiddleware:
         try:
             HomePage.objects.get(locale__language_code=get_language(), live=True)
         except HomePage.DoesNotExist:
-            activate('en-latest')
+            activate("en-latest")
             raise Http404()
         response = self.get_response(request)
         return response

--- a/apps/core/middleware.py
+++ b/apps/core/middleware.py
@@ -1,5 +1,5 @@
-from django.shortcuts import get_object_or_404
-from django.utils.translation import get_language
+from django.http import Http404
+from django.utils.translation import activate, get_language
 
 from apps.core.models import HomePage
 
@@ -9,6 +9,10 @@ class ValidateLocaleMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        get_object_or_404(HomePage, locale__language_code=get_language(), live=True)
+        try:
+            HomePage.objects.get(locale__language_code=get_language(), live=True)
+        except HomePage.DoesNotExist:
+            activate('en-latest')
+            raise Http404()
         response = self.get_response(request)
         return response

--- a/apps/core/templates/components/language_selector.html
+++ b/apps/core/templates/components/language_selector.html
@@ -2,11 +2,11 @@
 
 <div class="language-selector">
     <div class="language-selector__container">
+        {% if page %}
         <button class="language-selector__toggle dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
             {% get_language_info for LANGUAGE_CODE as lang %}
             <span class="language-selector__label">{{ lang.name_translated }} {% if page %}({% get_version_from_language_code page.localized.locale.language_code %}){% endif %}</span>
         </button>
-        {% if page %}
         {% spaceless %}
             <ul class="language-selector__dropdown dropdown-menu">
             {% for translation in page.get_translations.live %}


### PR DESCRIPTION
Fixes #263 

I think it is pointless to show a button with only the active locale (which might not have any pages at all) and simpler to just remove in those cases. The only case that I know of right now is the 404.html template which is just a dumb template that has no idea of where to direct the user to go.

I added a bit more logic in the homepage selection middleware introduced in #257 so that the english language is activated instead of the incorrectly selected one. That way the user has the site tree to the left to navigate to the english version of the guide.

### Before
<img width="1055" alt="Screenshot 2022-11-10 at 10 36 09" src="https://user-images.githubusercontent.com/143557/201069244-0a93734e-9094-4c42-94a0-51bbe9db178f.png">

### After
<img width="1139" alt="Screenshot 2022-11-10 at 10 37 18" src="https://user-images.githubusercontent.com/143557/201069242-1d7b0987-02e0-455a-ab46-d6bfc1874648.png">
