### PR TITLE
Fixes invalid redirection for /admin when browser is not set to English

### DIFF
--- a/apps/core/middleware.py
+++ b/apps/core/middleware.py
@@ -14,10 +14,11 @@ class ValidateLocaleMiddleware:
     def __call__(self, request):
         response = self.get_response(request)
         if request.resolver_match:
-            # Check if the path is in the i18n_patterns 
+            # Check if the path is in the i18n_patterns
             if pattern.match(request.resolver_match.route):
                 try:
-                    HomePage.objects.get(locale__language_code=get_language(), live=True)
+                    HomePage.objects.get(
+                        locale__language_code=get_language(), live=True)
                 except HomePage.DoesNotExist:
                     # Activate English so that we have a site menu
                     activate("en-latest")

--- a/apps/core/middleware.py
+++ b/apps/core/middleware.py
@@ -18,7 +18,8 @@ class ValidateLocaleMiddleware:
             if pattern.match(request.resolver_match.route):
                 try:
                     HomePage.objects.get(
-                        locale__language_code=get_language(), live=True)
+                        locale__language_code=get_language(), live=True
+                    )
                 except HomePage.DoesNotExist:
                     # Activate English so that we have a site menu
                     activate("en-latest")

--- a/apps/core/middleware.py
+++ b/apps/core/middleware.py
@@ -1,7 +1,10 @@
 from django.http import Http404
+from django.urls import LocalePrefixPattern
 from django.utils.translation import activate, get_language
 
 from apps.core.models import HomePage
+
+pattern = LocalePrefixPattern()
 
 
 class ValidateLocaleMiddleware:
@@ -9,10 +12,14 @@ class ValidateLocaleMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        try:
-            HomePage.objects.get(locale__language_code=get_language(), live=True)
-        except HomePage.DoesNotExist:
-            activate("en-latest")
-            raise Http404()
         response = self.get_response(request)
+        if request.resolver_match:
+            # Check if the path is in the i18n_patterns 
+            if pattern.match(request.resolver_match.route):
+                try:
+                    HomePage.objects.get(locale__language_code=get_language(), live=True)
+                except HomePage.DoesNotExist:
+                    # Activate English so that we have a site menu
+                    activate("en-latest")
+                    raise Http404()
         return response


### PR DESCRIPTION
Fixes #262.

Move the homepage lookup after response handling so that we have access to the url resolver. Then check if the requested path belongs to i18n_patterns so that we are not handling e.g. `/admin` as a localized URL.

To test this you will need to:

1. Make sure the browser language is english
    1.  Test that `/admin` works properly
    2. Test that  `/` works properly and redirects to `/en-latest``
2. Change browser language to Deutsch
    1. Test that `/admin` works properly 
    2. Test that `/` redirects to `/de-latest/` and shows a 404 page with the English menu