### PR TITLE
redirect to default language instead of a 404 error

### DIFF
--- a/apps/core/tests/test_locales.py
+++ b/apps/core/tests/test_locales.py
@@ -37,3 +37,9 @@ class TestPageLocales(TestCase):
         response = self.client.get(reverse("wagtailadmin_account"))
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertContains(response, "简体中文")
+
+    def test_redirect_to_default_language_if_no_translation_available(self):
+        language_code = "de-CH"
+        response = self.client.get("/", HTTP_ACCEPT_LANGUAGE=language_code, follow=True)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertRedirects(response, "/en-latest/")


### PR DESCRIPTION
If the root URL is opened with an HTTP_ACCEPT_LANGUAGE where no translation is available, a 404 error is returned. 
See issue https://github.com/wagtail/guide/issues/308.

Instead of a 404 error, users are now redirected to the default language.