### PR TITLE
render csrf token in feedback form

### DIFF
--- a/apps/core/templates/components/feedback.html
+++ b/apps/core/templates/components/feedback.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 
 <div class="feedback">
+    {% csrf_token %}
     <div class="feedback__container" data-feedback-container>
         <h2 class="feedback__heading">{% trans 'Was this page helpful?' %}</h2>
         <div class="feedback__options">

--- a/apps/core/tests/test_feedback.py
+++ b/apps/core/tests/test_feedback.py
@@ -1,5 +1,6 @@
 import json
 
+from django.conf import settings
 from django.test import TestCase
 
 from apps.core.factories import ContentPageFactory, HomePageFactory
@@ -63,3 +64,13 @@ class TestFeedback(TestCase):
         self.assertEqual(feedback_obj.feedback_text, "some test feedback text")
         self.assertEqual(feedback_obj.feedback, "unhappy")
         self.assertEqual(feedback_obj.page.specific, self.target_page)
+
+    def test_csrf_token_exists(self):
+        cookie = self.client.cookies.get(settings.CSRF_COOKIE_NAME)
+        self.assertIsNone(cookie)
+
+        # After opening a page, a cookie containing the CSRF token must be set,
+        # as it is used in the JS when submitting feedback.
+        self.client.get(self.target_page.url)
+        cookie = self.client.cookies.get(settings.CSRF_COOKIE_NAME)
+        self.assertIsNotNone(cookie)


### PR DESCRIPTION
fixes #311 by always setting a CSRF token when the feedback buttons are rendered.