### PR TITLE
Set height for alert icon

### DIFF
--- a/apps/frontend/static_src/scss/components/alert.scss
+++ b/apps/frontend/static_src/scss/components/alert.scss
@@ -24,6 +24,9 @@
         align-items: center;
         margin-inline-end: ($gutter * 0.5);
         height: 20px;
+        svg {
+            height: 100%;
+        }
     }
 
     &--note {

--- a/apps/frontend/static_src/scss/components/alert.scss
+++ b/apps/frontend/static_src/scss/components/alert.scss
@@ -24,6 +24,7 @@
         align-items: center;
         margin-inline-end: ($gutter * 0.5);
         height: 20px;
+
         svg {
             height: 100%;
         }


### PR DESCRIPTION
Fixes https://github.com/wagtail/guide/issues/281

#### Before
<img width="991" alt="Screenshot 2023-06-07 at 18 33 28" src="https://github.com/wagtail/guide/assets/27617/97828a9d-93cd-4790-ac9b-a3b3f556717a">

#### After
<img width="1002" alt="Screenshot 2023-06-07 at 18 33 02" src="https://github.com/wagtail/guide/assets/27617/98296a29-b9dd-4fe5-8391-4f773ac65d0e">
