### PR TITLE
Don't index search results

### DIFF
--- a/apps/core/templates/base.html
+++ b/apps/core/templates/base.html
@@ -22,7 +22,7 @@
         We don’t want older versions of the documentation to show up in search results.
         So we block all non-latest pages indexing with the robots=noindex meta tag.
         {% endcomment %}
-        {% if "latest" not in self.locale.language_code %}
+        {% if SEO_NOINDEX or "latest" not in self.locale.language_code %}
         <meta name="robots" content="noindex">
         {% endif %}
 

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -39,6 +39,7 @@ def search(request):
         {
             "search_query": search_query,
             "search_results": search_results,
+            "SEO_NOINDEX": True,
         },
     )
 


### PR DESCRIPTION
This prevents malicious index results from being created, and ensures Google doesn't waste its time on crawling the page.

See also https://github.com/wagtail/wagtail.org/pull/414