### PR TITLE
Full text search and partial matches in AJAX search form

### DIFF
--- a/apps/core/models/content.py
+++ b/apps/core/models/content.py
@@ -8,6 +8,7 @@ from django.utils.text import slugify
 from wagtail.admin.panels import FieldPanel
 from wagtail.fields import StreamField
 from wagtail.models import Page
+from wagtail.search import index
 
 from apps.core.models.feedback import Feedback
 
@@ -40,6 +41,8 @@ class ContentPage(Page):
     table_of_contents = models.TextField(blank=True)
 
     content_panels = Page.content_panels + [FieldPanel("body")]
+
+    search_fields = Page.search_fields + [index.SearchField("body")]
 
     def get_context(self, request, *args, **kwargs):
         if self.live and self.show_in_menus:

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -61,13 +61,11 @@ class PageSerializer(serializers.ModelSerializer):
 
 @api_view(["GET"])
 def search_json(request):
-
-    search_query = request.GET.get("query", None)
-
-    # Search
-    if search_query:
+    if search_query := request.GET.get("query"):
         search_results = (
-            Page.objects.live().filter(locale=Locale.get_active()).search(search_query)
+            Page.objects.live()
+            .filter(locale=Locale.get_active())
+            .autocomplete(search_query)
         )
         query = Query.get(search_query)
 


### PR DESCRIPTION
Fixes #371,  #278 and #290. Target the Wagtail 5.0 upgrades branch to use `autocomplete`.