### PR TITLE
Rich text images shadow + spacing

### DIFF
--- a/apps/frontend/static_src/scss/components/rich-text-image.scss
+++ b/apps/frontend/static_src/scss/components/rich-text-image.scss
@@ -1,11 +1,16 @@
 .richtext-image {
-    box-shadow: 2px 2px 8px 0 rgba($color--black, 0.3);
+    box-shadow: 2px 2px 50px 0 rgba($color--black, 0.05);
     border-radius: $border-radius--m;
 
     &.full-width {
         display: block;
         width: 100%;
         height: auto;
+        margin-top: ($gutter * 2);
+    }
+
+    + h3,
+    + h4 {
         margin-top: ($gutter * 2);
     }
 }


### PR DESCRIPTION
A request from @benenright to update the box-shadow on rich text images and add some space when a h3 or h4 tag follows. 

Box shadow before:

<details><summary>Details</summary>
<p>

![Screenshot 2024-06-11 at 09 38 59](https://github.com/wagtail/guide/assets/31627284/22c18810-6bba-4b86-985f-b8ab69068b0a)


</p>
</details> 

Box shadow after:

<details><summary>Details</summary>
<p>

![Screenshot 2024-06-11 at 09 39 11](https://github.com/wagtail/guide/assets/31627284/63d64370-f8c8-4e51-a667-e9058cffdbd3)


</p>
</details> 

Image and h3 spacing before:

<details><summary>Details</summary>
<p>

![Screenshot 2024-06-11 at 09 36 04](https://github.com/wagtail/guide/assets/31627284/23b968b3-6261-47ce-820c-98af13dea352)


</p>
</details> 

Image and h3 spacing after:

<details><summary>Details</summary>
<p>

![Screenshot 2024-06-11 at 09 36 12](https://github.com/wagtail/guide/assets/31627284/12534976-4648-4835-af38-65f682a6a454)

</p>
</details> 