### PR TITLE
Remove search bar spacing

### DIFF
--- a/apps/frontend/static_src/scss/components/search.scss
+++ b/apps/frontend/static_src/scss/components/search.scss
@@ -5,6 +5,7 @@
         display: flex;
         flex-direction: row;
         justify-content: stretch;
+        padding: 0;
     }
 
     &__input {


### PR DESCRIPTION
A request from @benenright to remove the space around the outside of the search dropdown.

Before:

<details><summary>Details</summary>
<p>

![Screenshot 2024-06-11 at 09 51 47](https://github.com/wagtail/guide/assets/31627284/caac0dd7-75bd-4c8b-8332-5dce7e6d4dfe)

</p>
</details> 

After:

<details><summary>Details</summary>
<p>

![Screenshot 2024-06-11 at 09 51 55](https://github.com/wagtail/guide/assets/31627284/8e29ef50-1d1a-402c-a5d2-ef8c93086449)


</p>
</details> 

The padding comes from the `.modal-body` class. I've overridden this on `.search__container` incase other elements use `.modal-body` and need the padding.