### PR TITLE
Refactor light-dark theming switch to always use light-dark CSS function

### DIFF
--- a/apps/frontend/static_src/scss/components/alert.scss
+++ b/apps/frontend/static_src/scss/components/alert.scss
@@ -36,7 +36,10 @@
         }
 
         #{$root}__content {
-            background-color: $color--extra-light-teal;
+            background-color: light-dark(
+                $color--extra-light-teal,
+                $color--black
+            );
         }
     }
 
@@ -46,7 +49,10 @@
         }
 
         #{$root}__content {
-            background-color: $color--extra-light-blue;
+            background-color: light-dark(
+                $color--extra-light-blue,
+                $color--black
+            );
         }
     }
 
@@ -58,15 +64,6 @@
             /* stylelint-disable-next-line declaration-no-important */
             margin: 0 !important;
             line-height: 1;
-        }
-    }
-
-    .theme-dark & {
-        &--note,
-        &--warning {
-            #{$root}__content {
-                background-color: $color--black;
-            }
         }
     }
 }

--- a/apps/frontend/static_src/scss/components/base.scss
+++ b/apps/frontend/static_src/scss/components/base.scss
@@ -8,34 +8,20 @@ html {
 }
 
 body {
-    background-color: $color--page-bg;
-    color: $color--off-black;
+    background-color: light-dark($color--page-bg, $color--off-black);
+    color: light-dark($color--off-black, $color--light-grey);
 
     &.no-scroll {
         overflow-y: hidden;
     }
-
-    &.theme-dark {
-        background-color: $color--off-black;
-        color: $color--light-grey;
-    }
 }
 
 a {
-    color: $color--primary;
+    color: light-dark($color--primary, $color--light-teal);
     transition: color $transition;
 
     &:hover,
     &:focus {
-        color: $color--black;
-    }
-
-    .theme-dark & {
-        color: $color--light-teal;
-
-        &:hover,
-        &:focus {
-            color: $color--white;
-        }
+        color: light-dark($color--black, $color--white);
     }
 }

--- a/apps/frontend/static_src/scss/components/burger.scss
+++ b/apps/frontend/static_src/scss/components/burger.scss
@@ -13,7 +13,7 @@
     &:hover,
     &:focus {
         #{$root}__line {
-            background-color: $color--primary;
+            background-color: light-dark($color--primary, $color--light-teal);
         }
     }
 
@@ -24,7 +24,7 @@
         width: 21px;
         height: 3px;
         border-radius: 4px;
-        background-color: $color--black;
+        background-color: light-dark($color--black, $color--white);
         opacity: 1;
         transform: translateX(-50%) rotate(0deg);
         transition: top $transition, width $transition, opacity $transition,
@@ -73,19 +73,6 @@
             .is-open & {
                 width: 0%;
                 inset: 15px auto auto 50%;
-            }
-        }
-    }
-
-    .theme-dark & {
-        #{$root}__line {
-            background-color: $color--white;
-        }
-
-        &:hover,
-        &:focus {
-            #{$root}__line {
-                background-color: $color--light-teal;
             }
         }
     }

--- a/apps/frontend/static_src/scss/components/copy-button.scss
+++ b/apps/frontend/static_src/scss/components/copy-button.scss
@@ -29,9 +29,9 @@
         @include fs(xxs);
         font-weight: 500;
         padding: 10px;
-        background-color: $color--white;
+        background-color: light-dark($color--white, $color--black);
         border: 1px solid rgba($color--grey, 0.4);
-        color: $color--off-black;
+        color: light-dark($color--off-black, $color--light-grey);
         cursor: pointer;
         transition: color $transition;
         position: relative;
@@ -43,35 +43,21 @@
 
         &:hover,
         &:focus {
-            color: $color--active;
-            border-color: $color--active;
+            color: light-dark($color--active, $color--light-teal);
+            border-color: light-dark($color--active, $color--light-teal);
             // Show a full outline around the button.
             z-index: 3;
-        }
-
-        .theme-dark & {
-            background-color: $color--black;
-            color: $color--light-grey;
-
-            &:hover,
-            &:focus {
-                color: $color--light-teal;
-                border-color: $color--light-teal;
-            }
         }
     }
 
     .dropdown-menu {
         --bs-dropdown-padding-y: 0.25rem;
-        --bs-dropdown-bg: #{$color--white};
+        --bs-dropdown-bg: light-dark(#{$color--white}, #{$color--black});
         --bs-dropdown-border-radius: #{$border-radius--m};
         border: 1px solid rgba($color--off-black, 0.15);
         box-shadow: 0 0.5rem 1rem rgba($color--black, 0.15);
-
-        .theme-dark & {
-            background-color: $color--black;
-            color: $color--white;
-        }
+        background-color: light-dark($color--white, $color--black);
+        color: light-dark(currentcolor, $color--white);
     }
 
     .dropdown-item {
@@ -82,15 +68,10 @@
 
         &:hover,
         &:active {
-            color: $color--active;
+            color: light-dark($color--active, $color--light-teal);
+            background-color: light-dark(transparent, rgba($color--white, 0.1));
         }
 
-        .theme-dark & {
-            color: $color--light-grey;
-
-            &:hover {
-                background-color: rgba($color--white, 0.1);
-            }
-        }
+        color: light-dark(currentcolor, $color--light-grey);
     }
 }

--- a/apps/frontend/static_src/scss/components/dropdown-toggle.scss
+++ b/apps/frontend/static_src/scss/components/dropdown-toggle.scss
@@ -1,15 +1,8 @@
 .dropdown-toggle {
-    $root: &;
     @include fs(xs);
     font-weight: 700;
 
     &::after {
-        color: $color--primary;
-    }
-
-    .theme-dark & {
-        &::after {
-            color: $color--light-teal;
-        }
+        color: light-dark($color--primary, $color--light-teal);
     }
 }

--- a/apps/frontend/static_src/scss/components/feedback-emoji.scss
+++ b/apps/frontend/static_src/scss/components/feedback-emoji.scss
@@ -1,22 +1,4 @@
 .feedback-emoji {
     width: 35px;
-    transition: fill $transition;
-
-    &:hover,
-    &:focus {
-        .feedback-emoji__path {
-            fill: $color--primary;
-        }
-    }
-
-    .theme-dark & {
-        fill: $color--light-grey;
-
-        &:hover,
-        &:focus {
-            .feedback-emoji__path {
-                fill: $color--light-teal;
-            }
-        }
-    }
+    fill: currentColor;
 }

--- a/apps/frontend/static_src/scss/components/footer.scss
+++ b/apps/frontend/static_src/scss/components/footer.scss
@@ -1,5 +1,5 @@
 .footer {
-    background-color: $color--blue;
+    background-color: light-dark($color--blue, $color--black);
     // For High-contrast mode users
     border-top: 1px solid $color--blue;
     padding: ($gutter * 2) 0 ($gutter * 3);
@@ -43,10 +43,6 @@
                 color: $color--white;
             }
         }
-    }
-
-    .theme-dark & {
-        background-color: $color--black;
     }
 }
 

--- a/apps/frontend/static_src/scss/components/header.scss
+++ b/apps/frontend/static_src/scss/components/header.scss
@@ -1,5 +1,4 @@
 .header {
-    $root: &;
     margin-top: $gutter;
     width: calc(100% + 16px); // burger align with right edge of lang
 
@@ -30,9 +29,21 @@
                 inset: -20px;
                 background: linear-gradient(
                     180deg,
-                    rgba($color--page-bg, 1) 0%,
-                    rgba($color--page-bg, 1) 40%,
-                    rgba($color--page-bg, 0) 100%
+                    light-dark(
+                            rgba($color--page-bg, 1),
+                            rgba($color--off-black, 1)
+                        )
+                        0%,
+                    light-dark(
+                            rgba($color--page-bg, 1),
+                            rgba($color--off-black, 1)
+                        )
+                        40%,
+                    light-dark(
+                            rgba($color--page-bg, 0),
+                            rgba($color--off-black, 0)
+                        )
+                        100%
                 );
                 height: 160px;
 
@@ -46,11 +57,11 @@
 
     &__logo {
         .light {
-            fill: $color--white;
+            fill: light-dark($color--white, $color--black);
         }
 
         .dark {
-            fill: $color--black;
+            fill: light-dark($color--black, $color--white);
         }
     }
 
@@ -134,7 +145,10 @@
                 inset-inline-start: -24px;
                 height: 30px;
                 width: 1px;
-                background-color: $color--off-black;
+                background-color: light-dark(
+                    $color--off-black,
+                    $color--light-grey
+                );
                 margin-inline-start: 20px;
                 margin-inline-end: 20px;
             }
@@ -148,41 +162,6 @@
 
     &__search-icon {
         display: block;
-        fill: $color--black;
-    }
-
-    .theme-dark & {
-        #{$root}__logo {
-            .light {
-                fill: $color--black;
-            }
-
-            .dark {
-                fill: $color--white;
-            }
-        }
-
-        #{$root}__search-toggle {
-            &::before {
-                background-color: $color--light-grey;
-            }
-        }
-
-        #{$root}__search-icon {
-            fill: $color--white;
-        }
-    }
-
-    .theme-dark.no-scroll & {
-        #{$root}__identity {
-            &::after {
-                background: linear-gradient(
-                    180deg,
-                    rgba($color--off-black, 1) 0%,
-                    rgba($color--off-black, 1) 40%,
-                    rgba($color--off-black, 0) 100%
-                );
-            }
-        }
+        fill: light-dark($color--black, $color--white);
     }
 }

--- a/apps/frontend/static_src/scss/components/heading.scss
+++ b/apps/frontend/static_src/scss/components/heading.scss
@@ -22,7 +22,7 @@ h6 {
             width: 70px;
             height: 1px;
             margin-top: ($gutter * 2);
-            background-color: $color--black;
+            background-color: currentColor;
         }
     }
 
@@ -30,15 +30,5 @@ h6 {
         @include fs(xxxxl);
         line-height: 1.1;
         margin-bottom: ($gutter * 2);
-    }
-
-    .theme-dark & {
-        &--one {
-            color: $color--white;
-
-            &::after {
-                background-color: $color--light-grey;
-            }
-        }
     }
 }

--- a/apps/frontend/static_src/scss/components/introduction.scss
+++ b/apps/frontend/static_src/scss/components/introduction.scss
@@ -1,9 +1,5 @@
 .introduction {
     font-size: $base-font-size;
     margin-bottom: ($gutter * 3);
-    color: $color--off-black;
-
-    .theme-dark & {
-        color: $color--light-grey;
-    }
+    color: light-dark($color--off-black, $color--light-grey);
 }

--- a/apps/frontend/static_src/scss/components/language-selector.scss
+++ b/apps/frontend/static_src/scss/components/language-selector.scss
@@ -1,15 +1,14 @@
 .language-selector {
-    $root: &;
     overflow: hidden;
 
     &__toggle {
         @include fs(xxs);
         font-weight: 500;
         padding: 10px;
-        background-color: $color--white;
+        background-color: light-dark($color--white, $color--black);
         border: 1px solid rgba($color--grey, 0.4);
         border-radius: $border-radius--m;
-        color: $color--off-black;
+        color: light-dark($color--off-black, $color--light-grey);
         cursor: pointer;
         transition: color $transition;
 
@@ -20,18 +19,20 @@
 
         &:hover,
         &:focus {
-            color: $color--active;
-            border-color: $color--active;
+            color: light-dark($color--active, $color--light-teal);
+            border-color: light-dark($color--active, $color--light-teal);
         }
     }
 
     &__dropdown {
-        --bs-dropdown-bg: #{$color--white};
+        --bs-dropdown-bg: #{light-dark($color--white, $color--black)};
         overflow: hidden;
         border-radius: $border-radius--m;
         border: 1px solid rgba($color--off-black, 0.15);
         box-shadow: 0 0.5rem 1rem rgba($color--black, 0.15);
         padding: 0.5rem 0;
+        background-color: light-dark($color--white, $color--black);
+        color: light-dark($color--off-black, $color--light-grey);
     }
 
     &__dropdown-item {
@@ -41,20 +42,11 @@
         white-space: nowrap;
         max-width: 200px;
         width: auto;
-    }
 
-    .theme-dark & {
-        #{$root}__toggle,
-        #{$root}__dropdown {
-            background-color: $color--black;
-            color: $color--light-grey;
-        }
-        #{$root}__dropdown-item {
-            &:hover,
-            &:focus {
-                color: $color--light-teal;
-                border-color: $color--light-teal;
-            }
+        &:hover,
+        &:focus {
+            color: light-dark(currentcolor, $color--light-teal);
+            border-color: light-dark(currentcolor, $color--light-teal);
         }
     }
 }

--- a/apps/frontend/static_src/scss/components/nav-buttons.scss
+++ b/apps/frontend/static_src/scss/components/nav-buttons.scss
@@ -1,5 +1,4 @@
 .nav-buttons {
-    $root: &;
     display: flex;
     justify-content: space-between;
     margin-bottom: ($gutter * 3);
@@ -13,7 +12,7 @@
         display: flex;
         align-items: center;
         padding: ($gutter * 0.5) $gutter;
-        border: 1px solid $color--off-black;
+        border: 1px solid light-dark($color--off-black, $color--light-grey);
         border-radius: $border-radius--lg;
         color: $color--off-black;
         text-decoration: none;
@@ -44,11 +43,5 @@
     &__label {
         @include fs(xs);
         font-weight: 700;
-    }
-
-    .theme-dark & {
-        #{$root}__link {
-            border-color: $color--light-grey;
-        }
     }
 }

--- a/apps/frontend/static_src/scss/components/navigation.scss
+++ b/apps/frontend/static_src/scss/components/navigation.scss
@@ -1,5 +1,4 @@
 .navigation {
-    $root: &;
     list-style: none;
     padding: 2px 0 2px 2px; // to prevent outline being cropped off
     margin: 0;
@@ -18,12 +17,12 @@
         padding: 5px 10px;
         border-radius: $border-radius;
         text-decoration: none;
-        color: $color--off-black;
+        color: light-dark($color--off-black, $color--light-grey);
         transition: color $transition, background-color $transition;
 
         &:hover,
         &:focus {
-            background-color: $color--white;
+            background-color: light-dark($color--white, $color--black);
         }
 
         &--heading {
@@ -32,24 +31,8 @@
         }
 
         &.active {
-            background-color: $color--active;
-            color: $color--white;
-        }
-    }
-
-    .theme-dark & {
-        #{$root}__link {
-            color: $color--light-grey;
-
-            &:hover,
-            &:focus {
-                background-color: $color--black;
-            }
-
-            &.active {
-                background-color: $color--light-teal;
-                color: $color--black;
-            }
+            background-color: light-dark($color--active, $color--light-teal);
+            color: light-dark($color--white, $color--black);
         }
     }
 }

--- a/apps/frontend/static_src/scss/components/primary-nav.scss
+++ b/apps/frontend/static_src/scss/components/primary-nav.scss
@@ -2,7 +2,7 @@
     display: none;
     position: absolute;
     z-index: 5;
-    background-color: $color--page-bg;
+    background-color: light-dark($color--page-bg, $color--off-black);
     padding: ($gutter * 6) $gutter ($gutter * 2);
     top: 0;
     inset-inline-end: -$gutter;
@@ -32,13 +32,5 @@
 
     &.is-visible {
         display: block;
-    }
-
-    .theme-dark & {
-        background-color: $color--off-black;
-
-        @include media-query(large) {
-            background-color: transparent;
-        }
     }
 }

--- a/apps/frontend/static_src/scss/components/section.scss
+++ b/apps/frontend/static_src/scss/components/section.scss
@@ -31,11 +31,15 @@
         min-width: 100px;
         max-width: 100px;
         margin-inline-end: ($gutter * 2);
+
+        .svg_icon__original_path {
+            fill: light-dark(currentcolor, $color--white);
+        }
     }
 
     &__heading {
         @include fs(xl);
-        color: $color--black;
+        color: light-dark($color--black, $color--white);
         margin-bottom: ($gutter * 0.25);
         font-weight: 700;
         transition: color $transition;
@@ -43,27 +47,7 @@
 
     &__description {
         @include fs(xs);
-        color: $color--grey;
+        color: light-dark($color--grey, $color--light-grey);
         margin: 0;
-    }
-
-    .theme-dark & {
-        #{$root}__heading {
-            color: $color--white;
-        }
-
-        #{$root}__description {
-            color: $color--light-grey;
-        }
-
-        #{$root}__icon {
-            .svg_icon__original_path {
-                fill: $color--white;
-            }
-
-            .svg_icon__animated_path {
-                opacity: 0.9;
-            }
-        }
     }
 }

--- a/apps/frontend/static_src/scss/components/theme-toggle.scss
+++ b/apps/frontend/static_src/scss/components/theme-toggle.scss
@@ -10,7 +10,7 @@
 
     &__label {
         @include fs(xxs);
-        color: $color--off-black;
+        color: light-dark($color--off-black, $color--light-grey);
     }
 
     &__button {
@@ -25,7 +25,7 @@
         margin: 0 ($gutter * 0.5);
         display: inline-block;
         cursor: pointer;
-        background: $color--grey;
+        background: light-dark($color--grey, $color--light-grey);
 
         &::before {
             top: 4px;
@@ -36,7 +36,7 @@
             display: block;
             position: absolute;
             border-radius: 12px;
-            background-color: $color--light-grey;
+            background-color: light-dark($color--light-grey, $color--black);
             transition: inset-inline-start $transition;
         }
 
@@ -49,7 +49,7 @@
             display: block;
             position: absolute;
             border-radius: 0.5px;
-            background: $color--off-black;
+            background: light-dark($color--off-black, $color--light-grey);
         }
     }
 
@@ -57,7 +57,7 @@
         display: none;
     }
 
-    .theme-dark & {
+    :has([name='color-scheme'][content^='dark']) & {
         .dark-only {
             display: block;
         }
@@ -67,25 +67,17 @@
         }
 
         #{$root}__button {
-            background: $color--light-grey;
-
             &::before {
-                background: $color--black;
                 inset-inline-start: 4px;
             }
 
             &::after {
-                background: $color--light-grey;
                 top: -2px;
                 inset-inline-end: 2px;
                 width: 32px;
                 height: 32px;
                 border-radius: 16px;
             }
-        }
-
-        #{$root}__label {
-            color: $color--light-grey;
         }
     }
 }


### PR DESCRIPTION
Streamlining to reduce the number of overrides needed. The stylesheets use a lot of nesting, so avoiding one layer project-wide makes a big difference.	