### PR TITLE
docs: update Poetry env activation command for Poetry 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can access the administrative area at [http://127.0.0.1:8000/admin](http://1
 
 To activate Poetry's virtual environment, run:
 
-    poetry shell
+    source $(poetry env activate)
 
 To generate and compile translation strings, run:
 


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->

### Description

update Poetry env activation command for Poetry 2.x as the poetry shell command is no longer used.

Since Poetry 2.0.0, the `poetry shell` command is no longer installed by default.

This replaces it with `source $(poetry env activate)`, which is the recommended approach.

Documentation: https://python-poetry.org/docs/managing-environments/#activating-the-environment


### AI usage
None
<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
