### PR TITLE
Upgrade Wagtail to 7.4 LTS

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -605,14 +605,14 @@ django = "*"
 
 [[package]]
 name = "django-modelcluster"
-version = "6.4.1"
+version = "6.5"
 description = "Django extension to allow working with 'clusters' of models as a single unit, independently of the database"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "django_modelcluster-6.4.1-py2.py3-none-any.whl", hash = "sha256:ccc190cd9e22c24900ea2410bff64d444d48f43f0f4aedeed0f6cd94e2536698"},
-    {file = "django_modelcluster-6.4.1.tar.gz", hash = "sha256:e736fcee925f83b63218dbf9c869ab50618b0f5e98869a5aa497f7a5331aa263"},
+    {file = "django_modelcluster-6.5-py3-none-any.whl", hash = "sha256:469b380a294027d5211d0e5d5746e0381f445b058d2229977a58fe0f1c58a596"},
+    {file = "django_modelcluster-6.5.tar.gz", hash = "sha256:459cbf0fb3bbc8c15ea9a2a062abc0d1ef935a38e04aa8ac3cb241c826bbc6dd"},
 ]
 
 [package.dependencies]
@@ -1451,19 +1451,19 @@ files = [
 
 [[package]]
 name = "modelsearch"
-version = "1.1.1"
+version = "1.3.1"
 description = "A library for indexing Django models with Elasicsearch, OpenSearch or database and searching them with the Django ORM."
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "modelsearch-1.1.1-py3-none-any.whl", hash = "sha256:d2580790af76c3a6404f651c9d8ca8695b284551583bb8ca6ddeb17eca0cfb52"},
-    {file = "modelsearch-1.1.1.tar.gz", hash = "sha256:25f329c4d93572729c931f65c46cedb5cfc32d368690ebdabc223aa6205251d6"},
+    {file = "modelsearch-1.3.1-py3-none-any.whl", hash = "sha256:a92847f01788d0d615e8715fabb8e823029288840297fb9e7235ee03ad49b6a8"},
+    {file = "modelsearch-1.3.1.tar.gz", hash = "sha256:f3b2e304dbef9f7c838423f591cfe0c60f4cef584bae8793d2aa8ac35a3c46e0"},
 ]
 
 [package.dependencies]
 Django = ">=4.2"
-django-tasks = ">=0.7,<0.10"
+django-tasks = ">=0.7,<0.13"
 
 [package.extras]
 dev = ["pre-commit (==3.4.0)", "ruff (==0.13.0)"]
@@ -2515,30 +2515,30 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "wagtail"
-version = "7.3"
+version = "7.4"
 description = "A Django content management system."
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "wagtail-7.3-py3-none-any.whl", hash = "sha256:519c84c47bccc2e42182a3879c6efe9f34d7233239b2899a99139ae3e17c5266"},
-    {file = "wagtail-7.3.tar.gz", hash = "sha256:81c3449652b17341fc794d65bdd208ae9e15f21743e8a6ca6bc2ce2e7b7312ce"},
+    {file = "wagtail-7.4-py3-none-any.whl", hash = "sha256:24a4d55e6bed22ccce4aae1b3f7e22a46605c4bc4dc9894d5a415cde418840c6"},
+    {file = "wagtail-7.4.tar.gz", hash = "sha256:9570c51d61ee524cc5558a84df40e2ccc03f7c50c6dad343644a45d037096d13"},
 ]
 
 [package.dependencies]
 anyascii = ">=0.1.5"
-beautifulsoup4 = ">=4.8,<5"
-Django = ">=4.2"
+beautifulsoup4 = ">=4.13.3,<5"
+Django = ">=5.2"
 django-filter = ">=23.3"
-django-modelcluster = ">=6.4.1,<7.0"
+django-modelcluster = ">=6.5,<7.0"
 django-permissionedforms = ">=0.1,<1.0"
 django-taggit = ">=5.0,<7"
-django-tasks = ">=0.9,<0.12"
-django-treebeard = ">=4.5.1,<5.0"
+django-tasks = ">=0.9,<0.13"
+django-treebeard = ">=4.8,<6.0"
 djangorestframework = ">=3.15.1,<4.0"
 draftjs_exporter = ">=2.1.5,<6.0"
 laces = ">=0.1,<0.2"
-modelsearch = ">=1.1,<1.2"
+modelsearch = ">=1.3,<1.4"
 openpyxl = ">=3.0.10,<4.0"
 Pillow = ">=9.1.0"
 requests = ">=2.11.1,<3.0"
@@ -2546,8 +2546,8 @@ telepath = ">=0.3.1,<1"
 Willow = {version = ">=1.11.0,<2", extras = ["heif"]}
 
 [package.extras]
-docs = ["Sphinx (>=7.3)", "myst_parser (==2.0.0)", "pyenchant (>=3.1.1,<4)", "sphinx-autobuild (>=0.6.0)", "sphinx-wagtail-theme (==6.5.0)", "sphinx_llm (>=0.2.1)", "sphinxcontrib-spelling (>=7,<8)"]
-testing = ["Jinja2 (>=3.0,<3.2)", "azure-mgmt-cdn (>=12.0,<13.0)", "azure-mgmt-frontdoor (>=1.0,<1.1)", "boto3 (>=1.28,<2)", "coverage (>=3.7.0)", "curlylint (==0.13.1)", "django-pattern-library (>=0.7)", "djhtml (==3.0.6)", "doc8 (==1.1.2)", "factory-boy (>=3.2)", "freezegun (>=0.3.8)", "polib (>=1.1,<2.0)", "python-dateutil (>=2.7)", "responses (>=0.25,<1)", "ruff (==0.9.6)", "semgrep (==1.132.0)", "tblib (>=2.0,<3.0)"]
+docs = ["Sphinx (>=7.3)", "myst_parser (>=4.0.0,<6)", "pyenchant (>=3.3.0,<4)", "sphinx-autobuild (>=0.6.0)", "sphinx-wagtail-theme (>=6.5.0,<7)", "sphinx_llm (>=0.2.1)", "sphinxcontrib-spelling (>=8,<9)"]
+testing = ["Jinja2 (>=3.0,<3.2)", "azure-mgmt-cdn (>=12.0,<13.0)", "azure-mgmt-frontdoor (>=1.0,<1.1)", "boto3 (>=1.28,<2)", "coverage (>=3.7.0)", "curlylint (==0.13.1)", "django-pattern-library (>=0.7)", "djhtml (==3.0.10)", "doc8 (==2.0.0)", "factory-boy (>=3.2)", "freezegun (>=0.3.8)", "polib (>=1.1,<2.0)", "responses (>=0.25,<1)", "ruff (==0.15.2)", "semgrep (==1.152.0)", "tblib (>=3.0,<4.0)"]
 
 [[package]]
 name = "wagtail-ai"
@@ -2657,4 +2657,4 @@ wand = ["Wand (>=0.6,<1.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.14"
-content-hash = "1e15f3a7e2389bfbc8f1ea529dcef419f79557c38ef72e96824d2b10c27d502c"
+content-hash = "31101cc3393950694ec6675c556a2041e946040b6c0df2b06d7446e305f0581b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = ">=3.14"
 django = ">=5.2,<6.0"
-wagtail = ">=7.3,<7.4"
+wagtail = ">=7.4,<7.5"
 django-manifest-loader = "^1.0.0"
 lxml = ">=4.9,<7"
 djangorestframework = ">=3.13.1,<4.0"


### PR DESCRIPTION
## Summary

Upgrades the `wagtail/guide` project from **Wagtail 7.3 → 7.4 LTS** in a single feature-release step. All baseline QA stays green, no code changes were required, and no deprecation warnings were introduced.

- **Files changed:** `pyproject.toml`, `poetry.lock` (21 +/- lines)
- **Migrations applied:** 4 (all from Wagtail core apps)

## Methodology and assumptions

- Treated the project as a **site/app**, so the Wagtail constraint was bumped to a single new range (not extended).
- Used **Poetry 2.2.1** for dependency management.
- Re-ran the project's own `make` targets (`lint`, `test`, `check`) plus extra deprecation-warning checks (`python -Wa`).
- No unrelated lint/formatting changes included.

## Upgrade path

| Component | Before | After | Notes |
|---|---|---|---|
| Python | `>=3.14` | `>=3.14` | No change — within 7.4 support (3.10–3.14) |
| Django | `>=5.2,<6.0` | `>=5.2,<6.0` | No change — within 7.4 support (5.2, 6.0) |
| Wagtail | `>=7.3,<7.4` | `>=7.4,<7.5` | Single feature step, 7.4 is LTS |

7.4 LTS receives security and data-loss fixes through 2 November 2027.

## Dependency changes

Direct bump:

| Package | From | To |
|---|---|---|
| `wagtail` | 7.3 | 7.4 |

Transitive bumps pulled in by 7.4's requirements:

| Package | From | To | Reason |
|---|---|---|---|
| `django-modelcluster` | 6.4.1 | 6.5 | Fixes for duplicated inline children |
| `modelsearch` | 1.1.1 | 1.3.1 | Search enhancements (fuzzy on PostgreSQL, ranking on SQLite) |

Other Wagtail-related deps reviewed (no changes needed):

| Package | Pinned | Status |
|---|---|---|
| `wagtail-localize` | `1.12.2` | OK with 7.4 (declares `Wagtail>=6.3`, `Framework :: Wagtail :: 7`) |
| `wagtail-ai` | `3.1.0` | OK with 7.4 (declares `Wagtail>=7.1`) |
| `wagtail-factories` | `^4.1.0` | OK with 7.4 (declares `wagtail>=6.3`) |

## Upgrade considerations — review

Reviewed every category in the [7.4 release notes](https://docs.wagtail.org/en/latest/releases/7.4.html):

| Item | Status for this project |
|---|---|
| Removed support for Django 4.2 | **Not affected** — already on Django 5.2 |
| New `w-block-` CSS class prefix on StreamField blocks (additive, legacy `block-` still emitted) | **Not affected** — no template/SCSS uses `block-text`, `block-alert`, `block-section`, `block-section_grid` selectors |
| `AccessibilityItem` → `ContentCheckerItem` userbar rename | **Not affected** — no custom userbar items |
| Deprecation of `{% page_header_buttons %}` template tag | **Not affected** — not used in project templates |

Other 7.4 features are opt-in and have no impact unless adopted.

## QA results

| Check | Before | After |
|---|---|---|
| `manage.py check` | clean | clean |
| `makemigrations --check --dry-run` | no changes | no changes |
| `manage.py migrate` | up-to-date | 4 new migrations applied (`wagtailadmin.0006`, `wagtailcore.0097`, `wagtailsearch.0010`, `wagtailsearchpromotions.0008`) |
| `make test` | 48 passed | 48 passed |
| `python -Wa manage.py test` | no deprecation warnings | no deprecation warnings |
| `make lint-backend` (ruff) | clean | clean |
| `npm run lint:js` (eslint) | clean | clean |
| `npm run lint:css` (stylelint) | clean | clean |

## Opt-in changes worth considering as follow-ups

The project doesn't need to adopt these to stay supported on 7.4, but they may be useful for the guide site:

1. **[`empty-meta-description` content checker](https://docs.wagtail.org/en/latest/advanced_topics/accessibility_considerations.html#built-in-content-checker)** — now enabled by default; useful for SEO consistency on the guide.
2. **[`WAGTAILDOCS_MAX_UPLOAD_SIZE`](https://docs.wagtail.org/en/latest/reference/settings.html#wagtaildocs-max-upload-size)** — new setting introduced from the DINUM security audit; consider setting it to 10 MB (project template default) since the guide allows authors to upload documents.
3. **[`routablefullpageurl` template tag](https://docs.wagtail.org/en/latest/reference/contrib/routablepage.html#routablefullpageurl-template-tag)** — handy for the routable LLM/markdown views in `apps/llms_txt`.
4. **Deferred validation for StreamField drafts** — improves UX for content editors saving incomplete drafts; on by default with no action needed, but worth communicating to translators.
5. **Customizable page explorer via `PageViewSet`** — could simplify any planned content-management improvements.

## Suggested follow-up tasks

- **Author user-facing release notes content**: there is no `prompts/content/en-latest/releases/new-in-wagtail-7-4.md` yet. The `write-release-notes` skill is set up for this and should be run as a separate content task.
- **Other tech-debt**: `wagtail-localize` 1.12.2 → 1.13 is a separate, optional dependency upgrade that could be scheduled independently.

## Test plan

- [x] CI passes on this branch.
- [x] Log in to `/admin/` and confirm the dashboard renders.
- [x] Open an existing `ContentPage`, edit the StreamField (`text` and `alert` blocks), save as draft — verify deferred validation does not error on empty required subfields.
- [x] Use Preview, then publish.
- [x] Visit a published page, click the userbar content checker — verify it opens with the new annotations UI.
- [x] Visit a translated locale (e.g. `/fr-latest/`) and confirm `monkey_patches.py` still produces valid URLs.
- [x] Run `make buildfixtures` to confirm fixture builds work end-to-end with the new migrations.

## References

- [Wagtail 7.4 release notes](https://docs.wagtail.org/en/latest/releases/7.4.html)
- [Upgrading Wagtail](https://docs.wagtail.org/en/latest/releases/upgrading.html)
- [Release schedule](https://github.com/wagtail/wagtail/wiki/Release-schedule)

Made with [Cursor](https://cursor.com)