### PR TITLE
Add AGENTS.md

### DIFF
--- a/.agents/skills/write-release-notes/SKILL.md
+++ b/.agents/skills/write-release-notes/SKILL.md
@@ -14,82 +14,82 @@ Generate a CMS-user-facing release page from the official Wagtail developer rele
 
 Usage:
 
-- `/write-release-notes for v7.4`
-- `/write-release-notes for the latest release`
+-   `/write-release-notes for v7.4`
+-   `/write-release-notes for the latest release`
 
 ## Methodology
 
 ### Goals
 
-- Produce a single Markdown file at `prompts/content/en-latest/releases/new-in-wagtail-<X-Y>.md`, following the page template, structure, exclusion rules, and tone defined in the style guide.
-- Translate the developer release notes into plain language for content editors, moderators, and administrators who use Wagtail but don't write code for it.
-- Suggest other documentation changes and internal links to existing or newly-introduced docs.
+-   Produce a single Markdown file at `prompts/content/en-latest/releases/new-in-wagtail-<X-Y>.md`, following the page template, structure, exclusion rules, and tone defined in the style guide.
+-   Translate the developer release notes into plain language for content editors, moderators, and administrators who use Wagtail but don't write code for it.
+-   Suggest other documentation changes and internal links to existing or newly-introduced docs.
 
 ### Guardrails
 
-- Don't invent feature names, version numbers, contributors, release dates, or screenshot URLs — pull them from the developer release notes or leave a `<!-- TODO: screenshot - alt: ... -->` placeholder for the user to fill in.
-- Don't open a PR or commit. The skill ends with a file on disk for the user to review and add screenshots to.
+-   Don't invent feature names, version numbers, contributors, release dates, or screenshot URLs — pull them from the developer release notes or leave a `<!-- TODO: screenshot - alt: ... -->` placeholder for the user to fill in.
+-   Don't open a PR or commit. The skill ends with a file on disk for the user to review and add screenshots to.
 
 ### Inputs
 
 To detect from the context or request from the user if unclear:
 
-- **Target version** as `X.Y` (e.g. `7.4`). Default: ask the user, or resolve "latest" via the [release schedule](https://github.com/wagtail/wagtail/wiki/Release-schedule).
-- **Existing draft**. If the output file already exists, read it first and treat it as a starting point — preserve human edits (custom phrasing, screenshot URLs already filled in) rather than overwriting blindly.
+-   **Target version** as `X.Y` (e.g. `7.4`). Default: ask the user, or resolve "latest" via the [release schedule](https://github.com/wagtail/wagtail/wiki/Release-schedule).
+-   **Existing draft**. If the output file already exists, read it first and treat it as a starting point — preserve human edits (custom phrasing, screenshot URLs already filled in) rather than overwriting blindly.
 
 ### Reference data sources
 
 Always fetch the latest information from the canonical sources rather than relying on local caches.
 
-- **Style guide**: [Release notes guidance](../../../docs/style-guide.md#release-notes-guidance) — the source of truth for page structure, tone, what to include/exclude, and how to translate developer jargon.
-- **Developer release notes**: `https://docs.wagtail.org/en/latest/releases/<X.Y>.html.md`.
-- **Recent precedents**: `prompts/content/en-latest/releases/new-in-wagtail-<previous>.md` — read at least the two most recent for tone calibration.
-- **User guide pages worth linking to**: search `prompts/content/en-latest/` for destinations matching each new feature. Feel free to suggest documentation changes to link to.
+-   **Style guide**: [Release notes guidance](../../../docs/style-guide.md#release-notes-guidance) — the source of truth for page structure, tone, what to include/exclude, and how to translate developer jargon.
+-   **Developer release notes**: `https://docs.wagtail.org/en/latest/releases/<X.Y>.html.md`.
+-   **Recent precedents**: `prompts/content/en-latest/releases/new-in-wagtail-<previous>.md` — read at least the two most recent for tone calibration.
+-   **User guide pages worth linking to**: search `prompts/content/en-latest/` for destinations matching each new feature. Feel free to suggest documentation changes to link to.
 
 ### Reporting
 
 After writing the file, report:
 
-- The output path and the release notes URL fetched.
-- Each headline feature included, with one-line rationale.
-- Each developer-notes item that was deliberately excluded, grouped by reason (security / maintenance / deprecation / developer-only API / unclear user value).
-- Every `<!-- TODO: screenshot -->` marker, with suggested alt text.
-- Every internal link suggestion to documentation that needs to be created.
-- Suggested follow-ups: user guide pages under `prompts/content/en-latest/` that may need updates to acknowledge the new features.
+-   The output path and the release notes URL fetched.
+-   Each headline feature included, with one-line rationale.
+-   Each developer-notes item that was deliberately excluded, grouped by reason (security / maintenance / deprecation / developer-only API / unclear user value).
+-   Every `<!-- TODO: screenshot -->` marker, with suggested alt text.
+-   Every internal link suggestion to documentation that needs to be created.
+-   Suggested follow-ups: user guide pages under `prompts/content/en-latest/` that may need updates to acknowledge the new features.
 
 ## Steps
 
 ### 1. Resolve the target version and gather sources
 
-- [ ] Confirm the target version with the user, or resolve "latest" via the [release schedule](https://github.com/wagtail/wagtail/wiki/Release-schedule).
-- [ ] Compute the output filename: `prompts/content/en-latest/releases/new-in-wagtail-<X-Y>.md` (dash separator, not dot). Read it if it already exists.
-- [ ] Fetch the developer release notes Markdown source. Detect LTS designation by looking for "(LTS)" in the page title.
-- [ ] Read the [Release notes guidance](../../../docs/style-guide.md#release-notes-guidance) section of the style guide and the two most recent precedent files.
+-   [ ] Confirm the target version with the user, or resolve "latest" via the [release schedule](https://github.com/wagtail/wagtail/wiki/Release-schedule).
+-   [ ] Compute the output filename: `prompts/content/en-latest/releases/new-in-wagtail-<X-Y>.md` (dash separator, not dot). Read it if it already exists.
+-   [ ] Fetch the developer release notes Markdown source. Detect LTS designation by looking for "(LTS)" in the page title.
+-   [ ] Read the [Release notes guidance](../../../docs/style-guide.md#release-notes-guidance) section of the style guide and the two most recent precedent files.
 
 ### 2. Categorize every item from the developer release notes
 
 For each entry under "What's new", "Other features", and "Bug fixes", apply the [include/exclude rules](../../../docs/style-guide.md#what-to-include-and-exclude) from the style guide:
 
-- [ ] **Headline section**: significant features with CMS-user value, each becoming an H2.
-- [ ] **Other-improvements bullet**: smaller user-visible changes.
-- [ ] **Excluded**: record the reason for the report.
+-   [ ] **Headline section**: significant features with CMS-user value, each becoming an H2.
+-   [ ] **Other-improvements bullet**: smaller user-visible changes.
+-   [ ] **Excluded**: record the reason for the report.
 
 ### 3. Draft the page
 
-- [ ] Follow the guidance from the style guide. Preserve the closing call-to-action paragraph wording from past release pages as a starter.
-- [ ] For each headline H2, write 1–2 sentences from the user's perspective, translating developer wording per the [Content style](../../../docs/style-guide.md#content-style) guidance.
-- [ ] Include a screenshot placeholder near the top of every headline section:
+-   [ ] Follow the guidance from the style guide. Preserve the closing call-to-action paragraph wording from past release pages as a starter.
+-   [ ] For each headline H2, write 1–2 sentences from the user's perspective, translating developer wording per the [Content style](../../../docs/style-guide.md#content-style) guidance.
+-   [ ] Include a screenshot placeholder near the top of every headline section:
 
     ```html
     <!-- TODO: screenshot - suggested alt: "<long descriptive alt text>" -->
     ```
 
-- [ ] Build "Other UI improvements" as a short bullet list ordered by user impact.
-- [ ] Add "Feedback requests" only if the developer notes link to an active discussion or feedback channel.
-- [ ] For LTS releases, add a single sentence to the opening paragraph noting LTS status.
+-   [ ] Build "Other UI improvements" as a short bullet list ordered by user impact.
+-   [ ] Add "Feedback requests" only if the developer notes link to an active discussion or feedback channel.
+-   [ ] For LTS releases, add a single sentence to the opening paragraph noting LTS status.
 
 ### 4. Write the file and report
 
-- [ ] Save to the output path. Preserve any pre-existing human edits when merging.
-- [ ] Lint the file by reading it back: H1 appears once, every H2 has at least one paragraph, every screenshot placeholder has suggested alt text, the closing call-to-action paragraph matches the established wording, and `<X.Y>` placeholders are all replaced.
-- [ ] Report per the "Reporting" section above.
+-   [ ] Save to the output path. Preserve any pre-existing human edits when merging.
+-   [ ] Lint the file by reading it back: H1 appears once, every H2 has at least one paragraph, every screenshot placeholder has suggested alt text, the closing call-to-action paragraph matches the established wording, and `<X.Y>` placeholders are all replaced.
+-   [ ] Report per the "Reporting" section above.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,6 @@ Defined in `ruff.toml`, `.eslintrc.json`, `.prettierrc.json`, `.stylelintrc.json
 ## Commit & pull request guidelines
 
 -   Be concise and to the point. Explain rationales that aren’t obvious.
--   Recent commit messages use short, capitalized, imperative summaries (e.g., “Enforce additional mypy check”).
+-   Commit messages must be a single line, short, capitalized, imperative summary. Do not add a description body unless explicitly asked.
 -   Always add a disclaimer to the PR description mentioning how AI agents are involved with the contribution.
 -   Do not add commits unrelated to the PR — check commit history against upstream main before pushing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,6 @@ Defined in `ruff.toml`, `.eslintrc.json`, `.prettierrc.json`, `.stylelintrc.json
 ## Commit & pull request guidelines
 
 -   Be concise and to the point. Explain rationales that aren’t obvious.
--   Commit messages must be a single line, short, capitalized, imperative summary. Do not add a description body unless explicitly asked.
+-   Commit messages must be a single line, short, sentence case, imperative summary. Do not add a description body unless explicitly asked.
 -   Always add a disclaimer to the PR description mentioning how AI agents are involved with the contribution.
 -   Do not add commits unrelated to the PR — check commit history against upstream main before pushing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS instructions
+
+Important context for AI coding agents working on this project.
+
+## Development commands
+
+- `make lint`: Lint the project.
+- `make format`: Format project files.
+- `make test`: Run tests.
+- `source $(poetry env activate)`: Activate Poetry's virtual environment.
+- `make translations`: Generate and Compile translation strings.
+
+## Setup & run commands
+- `make backend`:Build the backend.
+- `make frontend`:Build the frontend.  
+- `make buildfixtures`:Build the test fixtures.  
+- `make run`: Run the development server.
+
+## Docker setup
+
+Create a `.env` file in the project root with:
+ ```
+ALLOWED_HOSTS=localhost
+PORT=8000
+SECRET_KEY=some-random-secret
+DJANGO_SETTINGS_MODULE=apps.guide.settings.dev
+ ```
+### Docker commands 
+- `make docker-build`: Build the Docker image.
+- `make docker-run`: Run the Docker container.
+- `make docker-init`: Initialize the project inside the container.
+
+## Coding style & naming conventions
+Defined in `ruff.toml`, `.eslintrc.json`, `.prettierrc.json`, `.stylelintrc.json`:
+- **Python**: 4 spaces indent, `ruff format` (line-length 88, target py312)
+- **JavaScript**: `eslint` with `@wagtail/eslint-config-wagtail`
+- **Formatting**: `prettier` (`singleQuote`, `trailingComma: all`)
+- **SCSS/CSS**: `stylelint` with `@wagtail/stylelint-config-wagtail` (strict color values)
+- **Tests**: modules named `test_*.py`, classes named `Test*`, methods named `test_*`
+
+## Commit & pull request guidelines
+- Be concise and to the point. Explain rationales that aren’t obvious.
+- Recent commit messages use short, capitalized, imperative summaries (e.g., “Enforce additional mypy check”).
+- PRs should include a clear description,  links to any related issues.
+- Always add a disclaimer to the PR description mentioning how AI agents are involved with the contribution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,42 +4,49 @@ Important context for AI coding agents working on this project.
 
 ## Development commands
 
-- `make lint`: Lint the project.
-- `make format`: Format project files.
-- `make test`: Run tests.
-- `source $(poetry env activate)`: Activate Poetry's virtual environment.
-- `make translations`: Generate and Compile translation strings.
+-   `make lint`: Lint the project.
+-   `make format`: Format project files.
+-   `make test`: Run tests.
+-   `source $(poetry env activate)`: Activate Poetry's virtual environment.
+-   `make translations`: Generate and Compile translation strings.
 
 ## Setup & run commands
-- `make backend`:Build the backend.
-- `make frontend`:Build the frontend.  
-- `make buildfixtures`:Build the test fixtures.  
-- `make run`: Run the development server.
+
+-   `make backend`:Build the backend.
+-   `make frontend`:Build the frontend.
+-   `make buildfixtures`:Build the test fixtures.
+-   `make run`: Run the development server.
 
 ## Docker setup
 
 Create a `.env` file in the project root with:
- ```
+
+```
 ALLOWED_HOSTS=localhost
 PORT=8000
 SECRET_KEY=some-random-secret
 DJANGO_SETTINGS_MODULE=apps.guide.settings.dev
- ```
-### Docker commands 
-- `make docker-build`: Build the Docker image.
-- `make docker-run`: Run the Docker container.
-- `make docker-init`: Initialize the project inside the container.
+```
+
+### Docker commands
+
+-   `make docker-build`: Build the Docker image.
+-   `make docker-run`: Run the Docker container.
+-   `make docker-init`: Initialize the project inside the container.
 
 ## Coding style & naming conventions
+
 Defined in `ruff.toml`, `.eslintrc.json`, `.prettierrc.json`, `.stylelintrc.json`:
-- **Python**: 4 spaces indent, `ruff format` (line-length 88, target py312)
-- **JavaScript**: `eslint` with `@wagtail/eslint-config-wagtail`
-- **Formatting**: `prettier` (`singleQuote`, `trailingComma: all`)
-- **SCSS/CSS**: `stylelint` with `@wagtail/stylelint-config-wagtail` (strict color values)
-- **Tests**: modules named `test_*.py`, classes named `Test*`, methods named `test_*`
+
+-   **Python**: 4 spaces indent, `ruff format` (line-length 88, target py312)
+-   **JavaScript**: `eslint` with `@wagtail/eslint-config-wagtail`
+-   **Formatting**: `prettier` (`singleQuote`, `trailingComma: all`)
+-   **SCSS/CSS**: `stylelint` with `@wagtail/stylelint-config-wagtail` (strict color values)
+-   **Tests**: modules named `test_*.py`, classes named `Test*`, methods named `test_*`
 
 ## Commit & pull request guidelines
-- Be concise and to the point. Explain rationales that aren’t obvious.
-- Recent commit messages use short, capitalized, imperative summaries (e.g., “Enforce additional mypy check”).
-- PRs should include a clear description,  links to any related issues.
-- Always add a disclaimer to the PR description mentioning how AI agents are involved with the contribution.
+
+-   Be concise and to the point. Explain rationales that aren’t obvious.
+-   Recent commit messages use short, capitalized, imperative summaries (e.g., “Enforce additional mypy check”).
+-   PRs should include a clear description, links to any related issues.
+-   Always add a disclaimer to the PR description mentioning how AI agents are involved with the contribution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,12 @@ Important context for AI coding agents working on this project.
 
 ## Development commands
 
+> **Note:** Run `source "$(poetry env activate)"` before any `make` command, These require the Poetry virtual environment to be active.
+
 -   `make lint`: Lint the project.
 -   `make format`: Format project files.
 -   `make test`: Run tests.
--   `source $(poetry env activate)`: Activate Poetry's virtual environment.
--   `make translations`: Generate and Compile translation strings.
+-   `make translations`: Generate and compile translation strings.
 
 ## Setup & run commands
 
@@ -48,5 +49,5 @@ Defined in `ruff.toml`, `.eslintrc.json`, `.prettierrc.json`, `.stylelintrc.json
 
 -   Be concise and to the point. Explain rationales that aren’t obvious.
 -   Recent commit messages use short, capitalized, imperative summaries (e.g., “Enforce additional mypy check”).
--   PRs should include a clear description, links to any related issues.
 -   Always add a disclaimer to the PR description mentioning how AI agents are involved with the contribution.
+-   Do not add commits unrelated to the PR — check commit history against upstream main before pushing.


### PR DESCRIPTION
Fixes #436

### Description
Add an `AGENTS.md` file at the project root to provide agent-focused instructions for AI coding assistants. This complements the human-oriented `README.md` with build steps, test commands, coding style, and commit/PR conventions specifically relevant to agents.

### AI usage
 This pull request includes a PR description written with the assistance of AI. The code was written by a human and was reviewed and verified by me.