### PR TITLE
Remove unnecessary collectstatic step from CI test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
           cache: poetry
       - run: poetry install --no-root
       - run: poetry run python manage.py check
-      - run: poetry run python manage.py collectstatic --noinput --clear
       - run: poetry run python manage.py createcachetable
       - run: poetry run python manage.py makemigrations --check
       - run: mkdir ./apps/frontend/static && echo "{}" > ./apps/frontend/static/manifest.json


### PR DESCRIPTION
Relates to #406

### Description

The CI test workflow was running `collectstatic` before tests, but this is unnecessary because the test settings (`apps/guide/settings/test.py`) already use `CompressedStaticFilesStorage`, which serves static files directly from app directories without requiring them to be collected into `STATIC_ROOT`.

The `collectstatic` command was doing nothing useful for the test run. The only static-file-related requirement for tests is that `manifest.json` exists (for `manifest_loader`), which is already handled separately in the workflow.

### Changes

- Removed `poetry run python manage.py collectstatic --noinput --clear` from the CI test job

### Testing

- Ran `make test` locally with `DJANGO_SETTINGS_MODULE=apps.guide.settings.test`
- All 48 tests pass
- No lint errors in changed files

### AI usage

AI assisted with the PR description only , all code is reviewed by me.