### PR TITLE
Fix Poetry virtual environment activation command in installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can access the administrative area at [http://127.0.0.1:8000/admin](http://1
 
 To activate Poetry's virtual environment, run:
 
-    source $(poetry env activate)
+    eval $(poetry env activate)
 
 To generate and compile translation strings, run:
 


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


Fixes #454

### Description

Updates the installation guide’s Poetry virtual environment activation command.

The guide previously used:

```bash
source $(poetry env activate)
```

This is incorrect because `poetry env activate` outputs a shell command that must be evaluated in the current shell. The command has been updated to:

```bash
eval $(poetry env activate)
```

### AI usage

ChatGPT was used to help draft this pull request description.

