### PR TITLE
fix:fallback theme styles for browsers without light-dark() support

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,6 +1,12 @@
 {
   "extends": ["@wagtail/stylelint-config-wagtail"],
   "rules": {
+    "selector-pseudo-class-no-unknown": [
+      true,
+      {
+        "ignorePseudoClasses": ["global"]
+      }
+    ],
     "scale-unlimited/declaration-strict-value": [
       ["color", "/-color/", "fill", "stroke"],
       {

--- a/apps/frontend/static_src/scss/mixins.scss
+++ b/apps/frontend/static_src/scss/mixins.scss
@@ -87,3 +87,18 @@
         }
     }
 }
+
+@mixin light-dark($property, $light, $dark){
+
+    #{$property}: $light;
+    @supports (color: light-dark(#000, #fff)) {
+        #{$property}: light-dark(#{$light}, #{$dark});
+    }
+
+    @supports not (color: light-dark(#000, #fff)) {
+        :global(body.theme-dark) & {
+            #{$property}: $dark;
+        }
+    }
+}
+

--- a/apps/frontend/static_src/scss/mixins.scss
+++ b/apps/frontend/static_src/scss/mixins.scss
@@ -88,8 +88,7 @@
     }
 }
 
-@mixin light-dark($property, $light, $dark){
-
+@mixin light-dark($property, $light, $dark) {
     #{$property}: $light;
     @supports (color: light-dark(#000, #fff)) {
         #{$property}: light-dark(#{$light}, #{$dark});
@@ -101,4 +100,3 @@
         }
     }
 }
-


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #426

### Description

Add fallback theme styles for browsers without light-dark() support

### AI usage

AI has been for drafting in this issue , and researching the browser part.

### Also regarding new changes to the issue
 
the CSS light-dark() function is a relatively new feature and achieved baseline support across major modern browsers around May 2024.

Here is the breakdown of which older versions will NOT run this feature (i.e. they do not support light-dark()):

+ Chrome & Edge: Versions 122 and older will NOT support it. (Support was introduced in version 123, released in March 2024).
+ Firefox: Versions 119 and older will NOT support it. (Support was introduced in version 120, released in November 2023).
+ Safari: Versions 17.3 and older will NOT support it. (Support was introduced in version 17.4, released in March 2024).
+ Opera: Versions 108 and older will NOT support it. (Because Opera is based on Chromium, it gained support around the same time as Chrome 123, which maps to Opera 109).
