### PR TITLE
Move theme, language, and copy switchers to the burger menu (#199)

### DIFF
--- a/apps/core/templates/components/navigation.html
+++ b/apps/core/templates/components/navigation.html
@@ -1,6 +1,14 @@
 {% load wagtailcore_tags %}
 
 <nav class="primary-nav" data-mobile-menu>
+    <div class="primary-nav__tools">
+        {% include "components/theme_toggle.html" %}
+        {% if page.has_markdown_route %}
+            {% include "components/copy_button.html" %}
+        {% endif %}
+        {% include "components/language_selector.html" %}
+    </div>
+
     {% for item, info in annotated_list %}
         {% if info.open %}
             <ul class="navigation"><li class="navigation__item">

--- a/apps/core/templates/components/theme_toggle.html
+++ b/apps/core/templates/components/theme_toggle.html
@@ -2,7 +2,7 @@
 
 <div class="theme-toggle">
     <span class="theme-toggle__label">{% trans 'Dark' %}</span>
-    <button id="wagtail-theme" class="theme-toggle__button" type="button" aria-label="{% trans 'Toggle between dark and light theme' %}">
+    <button class="theme-toggle__button js-theme-toggle" type="button" aria-label="{% trans 'Toggle between dark and light theme' %}">
         <span class="dark-only u-sr-only">{% trans 'Light mode' %}</span>
         <span class="light-only u-sr-only">{% trans 'Dark mode' %}</span>
     </button>

--- a/apps/core/templatetags/core_tags.py
+++ b/apps/core/templatetags/core_tags.py
@@ -26,6 +26,8 @@ def header(context):
         "site_title": home.title,
         "current_page": context.get("page"),
         "annotated_list": Page.get_annotated_list_qs(pages),
+        "page": context.get("page"),
+        "request": context.get("request"),
     }
 
 

--- a/apps/frontend/static_src/js/theme-detect/index.js
+++ b/apps/frontend/static_src/js/theme-detect/index.js
@@ -1,4 +1,9 @@
-// Wire up light/dark mode button.
-document.getElementById('wagtail-theme').addEventListener('click', (event) => {
-    document.dispatchEvent(new CustomEvent('theme:toggle-theme-mode', event));
+// Wire up light/dark mode buttons (there may be more than one, e.g. one in
+// the header tools on desktop and one in the burger menu on mobile).
+document.querySelectorAll('.js-theme-toggle').forEach((button) => {
+    button.addEventListener('click', (event) => {
+        document.dispatchEvent(
+            new CustomEvent('theme:toggle-theme-mode', event),
+        );
+    });
 });

--- a/apps/frontend/static_src/scss/components/page-tools.scss
+++ b/apps/frontend/static_src/scss/components/page-tools.scss
@@ -1,11 +1,12 @@
 .page-tools {
     position: relative;
     z-index: 4;
-    display: flex;
+    display: none;
     justify-content: flex-end;
     margin-bottom: ($gutter * 2);
 
     @include media-query(large) {
+        display: flex;
         margin-bottom: ($gutter * 5);
     }
 }

--- a/apps/frontend/static_src/scss/components/primary-nav.scss
+++ b/apps/frontend/static_src/scss/components/primary-nav.scss
@@ -9,8 +9,8 @@
     max-height: 100vh;
     height: 100vh;
     overflow-x: scroll;
-    inset-inline-start: -10px; // ensure vertical reading line is aligned
-    width: calc(100% - 10px); // compensate for reading line adjustment
+    inset-inline-start: -10px;
+    width: calc(100% - 10px);
 
     @include media-query(medium) {
         inset-inline-end: -($gutter * 3);
@@ -34,11 +34,6 @@
     }
 }
 
-// Theme + language controls rendered at the top of the burger overlay on
-// mobile. Hidden on desktop (the nav becomes a sidebar there, and the
-// controls already live in .page-tools above the content).
-// The margin-top pushes the controls below the header's gradient mask
-// (header__identity::after, 160px tall) so their colors aren't washed out.
 .primary-nav__tools {
     margin-top: ($gutter * 2);
     margin-bottom: ($gutter * 2);
@@ -59,9 +54,6 @@
         margin-inline-end: 0;
 
         .copy-button__toggle {
-            // The container is auto-height inline-flex, so height: 100% does
-            // not resolve and leaves the arrow shorter than the button. Let
-            // the default cross-axis stretch fill it to match.
             height: auto;
         }
     }

--- a/apps/frontend/static_src/scss/components/primary-nav.scss
+++ b/apps/frontend/static_src/scss/components/primary-nav.scss
@@ -9,8 +9,8 @@
     max-height: 100vh;
     height: 100vh;
     overflow-x: scroll;
-    inset-inline-start: -10px;
-    width: calc(100% - 10px);
+    inset-inline-start: -10px; // ensure vertical reading line is aligned
+    width: calc(100% - 10px); // compensate for reading line adjustment
 
     @include media-query(medium) {
         inset-inline-end: -($gutter * 3);

--- a/apps/frontend/static_src/scss/components/primary-nav.scss
+++ b/apps/frontend/static_src/scss/components/primary-nav.scss
@@ -33,3 +33,40 @@
         display: block;
     }
 }
+
+// Theme + language controls rendered at the top of the burger overlay on
+// mobile. Hidden on desktop (the nav becomes a sidebar there, and the
+// controls already live in .page-tools above the content).
+// The margin-top pushes the controls below the header's gradient mask
+// (header__identity::after, 160px tall) so their colors aren't washed out.
+.primary-nav__tools {
+    margin-top: ($gutter * 2);
+    margin-bottom: ($gutter * 2);
+    padding-bottom: $gutter;
+    border-bottom: 1px solid
+        light-dark(rgba($color--off-black, 0.1), rgba($color--white, 0.1));
+
+    @include media-query(large) {
+        display: none;
+    }
+
+    .theme-toggle {
+        margin-inline-end: 0;
+    }
+
+    .copy-button {
+        margin-top: $gutter;
+        margin-inline-end: 0;
+
+        .copy-button__toggle {
+            // The container is auto-height inline-flex, so height: 100% does
+            // not resolve and leaves the arrow shorter than the button. Let
+            // the default cross-axis stretch fill it to match.
+            height: auto;
+        }
+    }
+
+    .language-selector {
+        margin-top: $gutter;
+    }
+}


### PR DESCRIPTION
Relates to #199

### Description

Moves the theme toggle, copy button, and language selector out of `.page-tools` (above the article content) and into the burger menu overlay on mobile, so they no longer take up space above the content on small screens.

Approach: render the tools in both places (`.page-tools` in `base.html` and `.primary-nav__tools` in `navigation.html`) and toggle visibility with CSS breakpoints — no JS DOM manipulation. The theme toggle button id was replaced with a `.js-theme-toggle` class so the JS wires up both instances.

Worth careful review:
- The copy-button Bootstrap dropdown inside the scrollable `.primary-nav` overlay may clip instead of overlay content on mobile — verify on a narrow viewport.
- `page`/`request` were added to the `header` inclusion-tag context; `request` is currently unused (kept defensively).

### Testing
- before
<img width="812" height="954" alt="Screenshot From 2026-08-05 17-18-55" src="https://github.com/user-attachments/assets/9fc5ecb4-76e8-4358-bcc2-3f8a4053b052" />
<img width="812" height="954" alt="Screenshot From 2026-08-05 17-18-50" src="https://github.com/user-attachments/assets/db1cdd1d-1995-4081-a545-3150785f6e66" />

- After
<img width="812" height="954" alt="Screenshot From 2026-08-05 17-19-04" src="https://github.com/user-attachments/assets/dbfaaa75-5a36-4c40-b0a8-b72d4c9f09c9" />
<img width="812" height="954" alt="Screenshot From 2026-08-05 17-18-39" src="https://github.com/user-attachments/assets/6054f917-c2ce-495e-9ee4-386b082ab770" />

### AI usage

- Agent: AI assisted with the PR description and review only. The code was written by a human; AI reviewed the diff and prepared this description.
