### PR TITLE
Fix Docker dev setup shadowing built front-end assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,13 @@ on:
   pull_request:
 
 jobs:
+  docker-build-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - run: docker build --check .
+
   test:
     runs-on: ubuntu-latest
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,9 +31,10 @@ DJANGO_SETTINGS_MODULE=apps.guide.settings.dev
 
 ### Docker commands
 
--   `just docker-build`: Build the Docker image.
--   `just docker-run`: Run the Docker container.
--   `just docker-init`: Initialize the project inside the container.
+-   `docker compose up --remove-orphans`: Build (if needed) and run the container.
+-   `docker compose exec web bash`: Open a shell in the container. The container bundles Python
+    and Node, so the same `just` commands (e.g. `just backend`, `just frontend`) work from there.
+-   `docker compose build`: Rebuild the image after a dependency change.
 
 ## Coding style & naming conventions
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,4 +124,4 @@ RUN SECRET_KEY=none python manage.py collectstatic --noinput --clear
 
 # Gunicorn config lives in gunicorn.conf.py (its default location), which
 # reads WEB_CONCURRENCY for the number of workers to spawn.
-CMD gunicorn
+CMD ["gunicorn"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,96 +1,127 @@
-# (Keep the version in sync with the node install below)
-FROM node:24 as frontend
+# syntax=docker/dockerfile:1.10
+# check=error=true
 
-# Make build & post-install scripts behave as if we were in a CI environment (e.g. for logging verbosity purposes).
+# Opt into newer Dockerfile syntax, make `docker build .` fail on warnings
+# See https://docs.docker.com/reference/build-checks/.
+# Run `docker build --check .` for better error messages.
+
+# frontend stages
+
+# Keep the Node version in sync with the dev stage below and .nvmrc.
+FROM node:24 AS frontend-deps
+
+# Make build & post-install scripts behave as if in CI (e.g. logging verbosity).
 ARG CI=true
 
-# Install front-end dependencies.
+# Split from frontend-build so the dev stage below can reuse node_modules
+# without needing to run the production build.
 COPY package.json package-lock.json webpack.config.js ./
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm npm ci
 
-# Compile static files
+FROM frontend-deps AS frontend-build
+
 COPY ./apps/frontend/static_src/ ./apps/frontend/static_src/
 RUN npm run build
 
+# base stage
 
-# We use Debian images because they are considered more stable than the alpine
-# ones becase they use a different C compiler. Debian images also come with
-# all useful packages required for image manipulation out of the box. They
-# however weigh a lot, approx. up to 1.5GiB per built image.
-FROM python:3.14 as production
+# Debian over alpine: it's considered more stable (different C compiler) and
+# ships with the packages commonly needed for image manipulation, at the
+# cost of a larger (~1.5GiB) image.
+FROM python:3.14 AS base
 
-# Install uv using the official standalone binary.
 # Keep this version in sync with the local `uv` used to generate uv.lock.
 COPY --from=ghcr.io/astral-sh/uv:0.11.19 /uv /uvx /bin/
 
-# Arguments to control which dependency groups get installed. Defaults to the
-# production configuration, and can be overridden at build time (e.g. for the
-# development container).
-ARG UV_SYNC_ARGS="--no-dev --group production"
-
-# Install dependencies in a virtualenv
 ENV VIRTUAL_ENV=/venv
 
 RUN useradd guide --create-home && mkdir /app $VIRTUAL_ENV && chown -R guide /app $VIRTUAL_ENV
 
 WORKDIR /app
 
-# Set default environment variables. They are used at build time and runtime.
-# If you specify your own environment variables on Heroku, they will
-# override the ones set here. The ones below serve as sane defaults only.
-#  * PATH - Make sure that uv is on the PATH, along with our venv
-#  * UV_PROJECT_ENVIRONMENT - Install dependencies into $VIRTUAL_ENV instead of
-#    the default `.venv` in the project directory.
-#  * UV_COMPILE_BYTECODE - Compile Python bytecode for faster container starts.
-#  * UV_LINK_MODE - Use copy mode to avoid hardlinks which break in Docker layers.
-#  * PYTHONUNBUFFERED - This is useful so Python does not hold any messages
-#    from being output.
+# Defaults only: any environment variables set on Heroku override these.
+#  * UV_PROJECT_ENVIRONMENT - installs into $VIRTUAL_ENV instead of the
+#    project's default `.venv`, so it isn't clobbered by a bind mount in dev.
+#  * UV_LINK_MODE=copy - hardlinks break across Docker layers.
+#  * PYTHONUNBUFFERED - otherwise logs can be lost if the process crashes:
 #    https://docs.python.org/3.14/using/cmdline.html#envvar-PYTHONUNBUFFERED
-#    https://docs.python.org/3.14/using/cmdline.html#cmdoption-u
-#  * DJANGO_SETTINGS_MODULE - default settings used in the container.
-#  * PORT - default port used. Please match with EXPOSE.
-#    Heroku will ignore EXPOSE and only set PORT variable. PORT variable is
-#    read/used by Gunicorn.
-#  * WEB_CONCURRENCY - number of workers used by Gunicorn. The variable is
-#    read by Gunicorn.
+#  * PORT - read by Gunicorn; Heroku sets this itself and ignores EXPOSE.
 ENV PATH=$VIRTUAL_ENV/bin:$PATH \
     UV_PROJECT_ENVIRONMENT=$VIRTUAL_ENV \
     UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
     PYTHONUNBUFFERED=1 \
-    DJANGO_SETTINGS_MODULE=apps.guide.settings.production \
-    PORT=8000 \
-    WEB_CONCURRENCY=2
+    PORT=8000
 
-# Make $BUILD_ENV available at runtime
-ARG BUILD_ENV
-ENV BUILD_ENV=${BUILD_ENV}
-
-# Port exposed by this container. Should default to the port used by your WSGI
-# server (Gunicorn). Heroku will ignore this.
 EXPOSE 8000
 
-# Don't use the root user as it's an anti-pattern and Heroku does not run
-# containers as root either.
+# Heroku doesn't run containers as root either:
 # https://devcenter.heroku.com/articles/container-registry-and-runtime#dockerfile-commands-and-runtime
 USER guide
 
-# Install your app's Python requirements.
 RUN python -m venv $VIRTUAL_ENV
 COPY --chown=guide pyproject.toml uv.lock ./
+
+
+# dev stage
+
+# Used by `docker compose` for local development. Application code isn't
+# copied in at build time - docker-compose bind mounts it instead - so only
+# rebuild this image when dependencies change (`docker compose build`).
+FROM base AS dev
+
+USER root
+
+# Node's major version is kept in sync with frontend-deps above and .nvmrc.
+# `just` is installed too, so the recipes in ./justfile also work from a
+# shell in this container, the same way they do on the host.
+RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    mkdir -p /etc/apt/keyrings \
+    && apt-get --quiet --yes update \
+    && apt-get --quiet --yes install --no-install-recommends ca-certificates curl gnupg \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get --quiet --yes update \
+    && apt-get --quiet --yes install --no-install-recommends nodejs \
+    && curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+
+USER guide
+
+ARG UV_SYNC_ARGS="--all-groups"
 RUN uv sync --frozen ${UV_SYNC_ARGS}
 
-COPY --chown=guide --from=frontend ./apps/frontend/static ./apps/frontend/static
+# Reuses node_modules from frontend-deps so a freshly built container doesn't
+# need to `npm ci` before assets can be built. docker-compose.yml volumes
+# node_modules so it isn't shadowed by the code bind mount.
+COPY --chown=guide --from=frontend-deps ./node_modules ./node_modules
+COPY --chown=guide package.json package-lock.json webpack.config.js ./
 
-# Copy application code.
+CMD ["uv", "run", "python", "manage.py", "runserver", "0.0.0.0:8000"]
+
+
+# production stage
+
+# Runs in production on Heroku. Last stage so it's the default target for an untargeted `docker build .`
+FROM base AS production
+
+# Can be overridden at build time, e.g. by the dev stage above.
+ARG UV_SYNC_ARGS="--no-dev --group production"
+
+ENV DJANGO_SETTINGS_MODULE=apps.guide.settings.production \
+    WEB_CONCURRENCY=2
+
+# ARGs aren't available at runtime, so re-declare as an ENV to pass it through.
+ARG BUILD_ENV
+ENV BUILD_ENV=${BUILD_ENV}
+
+RUN uv sync --frozen ${UV_SYNC_ARGS}
+
+COPY --chown=guide --from=frontend-build ./apps/frontend/static ./apps/frontend/static
 COPY --chown=guide . .
 
-# Collect static. This command will move static files from application
-# directories and "static_compiled" folder to the main static directory that
-# will be served by the WSGI server.
 RUN SECRET_KEY=none python manage.py collectstatic --noinput --clear
 
-# Run the WSGI server. Configuration lives in `gunicorn.conf.py`, which
-# configures the app, port and worker recycling. `WEB_CONCURRENCY` is read by
-# gunicorn to determine the number of workers.
+# Gunicorn config lives in gunicorn.conf.py (its default location), which
+# reads WEB_CONCURRENCY for the number of workers to spawn.
 CMD gunicorn

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,8 +83,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
     && apt-get --quiet --yes update \
-    && apt-get --quiet --yes install --no-install-recommends nodejs \
-    && curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+    && apt-get --quiet --yes install --no-install-recommends nodejs just
 
 USER guide
 

--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@ The user guide is a website to help content editors, moderators, administrators,
 
 The Wagtail guide will ultimately include:
 
--   Tutorials
--   How-to articles
--   Reference materials
--   Walkthroughs and visual learning materials
+- Tutorials
+- How-to articles
+- Reference materials
+- Walkthroughs and visual learning materials
 
 You can learn more about the documentation system [here](https://documentation.divio.com/).
 
 # Table of Contents
 
--   [Installation](#installation)
--   [Contributing](#contributing)
--   [Other Notes](#other-notes)
+- [Installation](#installation)
+- [Contributing](#contributing)
+- [Other Notes](#other-notes)
 
 # Installation
 
@@ -23,11 +23,11 @@ We assume that you have basic knowledge of Node/Webpack and Python/Django/Wagtai
 
 #### Dependencies
 
--   Git
--   Python >= 3.14
--   uv
--   just
--   Node (see `.nvmrc` for version)
+- Git
+- Python >= 3.14
+- uv
+- just
+- Node (see `.nvmrc` for version)
 
 ### Setting up Wagtail guide in a virtual environment
 
@@ -69,20 +69,24 @@ Or both, in a single command:
 
 ### Setting up development with Docker
 
-1. Optianally, create a `.env` file in the project root containing these variables, you can adjust the values to your preferences:
+1. Optionally, create a `.env` file in the project root containing these variables, you can adjust the values to your preferences:
     ```
     ALLOWED_HOSTS=localhost
     PORT=8000
     SECRET_KEY=some-random-secret
     DJANGO_SETTINGS_MODULE=apps.guide.settings.dev
     ```
-2. Build and start the development container by running the `just docker-run` command.
-   This starts the server in the foreground. To run it in the background, use `just docker-start` instead.
-3. In another terminal, run the init script in the container: `just docker-init`
-4. You should now have access to the project in your browser at `http://localhost:8000`
-5. To stop the container, run `just docker-stop`
+2. Build and start the development container by running `docker compose up --remove-orphans`.
+   This starts the server in the foreground. To run it in the background, add `-d`.
+3. In another terminal, open a shell in the container: `docker compose exec web bash`
+4. From that shell, run `just backend` to set up the database, and `just frontend` to build the
+   front-end assets. The container bundles Python and Node, so any other `just` recipe (`just
+test`, `just lint`, ...) works the same as it does on the host — you don't need either
+   installed locally to use Docker.
+5. You should now have access to the project in your browser at `http://localhost:8000`
+6. To stop the container, run `docker compose down`
 
-Code changes are picked up automatically. Only rebuild when dependencies change:`just docker-build`
+Code changes are picked up automatically. Only rebuild the image when dependencies change: `docker compose build`.
 
 # Contributing
 
@@ -90,9 +94,9 @@ If you're a Python or Django developer, fork the repo and join us. You'll find a
 
 ## Development
 
--   Run formatting (Ruff & Prettier) `just format`
--   Run linting (Ruff, Prettier, Eslint) `just lint`
--   Run tests `just test`
+- Run formatting (Ruff & Prettier) `just format`
+- Run linting (Ruff, Prettier, Eslint) `just lint`
+- Run tests `just test`
 
 # Other Notes
 
@@ -102,12 +106,12 @@ This project is one of three [Wagtail](https://wagtail.org/) projects being spon
 
 ### Contributor
 
--   [Hitansh Shah](https://github.com/Hitansh-Shah)
+- [Hitansh Shah](https://github.com/Hitansh-Shah)
 
 ### Mentors
 
--   [Thibaud Colas](https://github.com/thibaudcolas)
--   [Coen van der Kamp](https://github.com/allcaps)
--   [Meagen Voss](https://github.com/vossisboss)
+- [Thibaud Colas](https://github.com/thibaudcolas)
+- [Coen van der Kamp](https://github.com/allcaps)
+- [Meagen Voss](https://github.com/vossisboss)
 
 You can learn more about our Google Summer of Code project in [Google Summer of Code: Wagtail Editor Guide](https://wagtail.org/blog/google-summer-of-code-wagtail-editor-guide/), [Wagtail CMS projects for Google Summer of Code 2022](https://wagtail.org/blog/wagtail-cms-projects-for-google-summer-of-code-2022/) or on our [wiki page](https://github.com/wagtail/wagtail/wiki/Google-Summer-of-Code-2022).

--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@ The user guide is a website to help content editors, moderators, administrators,
 
 The Wagtail guide will ultimately include:
 
-- Tutorials
-- How-to articles
-- Reference materials
-- Walkthroughs and visual learning materials
+-   Tutorials
+-   How-to articles
+-   Reference materials
+-   Walkthroughs and visual learning materials
 
 You can learn more about the documentation system [here](https://documentation.divio.com/).
 
 # Table of Contents
 
-- [Installation](#installation)
-- [Contributing](#contributing)
-- [Other Notes](#other-notes)
+-   [Installation](#installation)
+-   [Contributing](#contributing)
+-   [Other Notes](#other-notes)
 
 # Installation
 
@@ -23,11 +23,11 @@ We assume that you have basic knowledge of Node/Webpack and Python/Django/Wagtai
 
 #### Dependencies
 
-- Git
-- Python >= 3.14
-- uv
-- just
-- Node (see `.nvmrc` for version)
+-   Git
+-   Python >= 3.14
+-   uv
+-   just
+-   Node (see `.nvmrc` for version)
 
 ### Setting up Wagtail guide in a virtual environment
 
@@ -79,10 +79,7 @@ Or both, in a single command:
 2. Build and start the development container by running `docker compose up --remove-orphans`.
    This starts the server in the foreground. To run it in the background, add `-d`.
 3. In another terminal, open a shell in the container: `docker compose exec web bash`
-4. From that shell, run `just backend` to set up the database, and `just frontend` to build the
-   front-end assets. The container bundles Python and Node, so any other `just` recipe (`just
-test`, `just lint`, ...) works the same as it does on the host — you don't need either
-   installed locally to use Docker.
+4. From that shell, run `just backend` to set up the database, and `just frontend` to build the front-end assets. The container bundles Python and Node, so any other `just` recipe (`just test`, `just lint`, ...) works the same as it does on the host — you don't need either installed locally to use Docker.
 5. You should now have access to the project in your browser at `http://localhost:8000`
 6. To stop the container, run `docker compose down`
 
@@ -94,9 +91,9 @@ If you're a Python or Django developer, fork the repo and join us. You'll find a
 
 ## Development
 
-- Run formatting (Ruff & Prettier) `just format`
-- Run linting (Ruff, Prettier, Eslint) `just lint`
-- Run tests `just test`
+-   Run formatting (Ruff & Prettier) `just format`
+-   Run linting (Ruff, Prettier, Eslint) `just lint`
+-   Run tests `just test`
 
 # Other Notes
 
@@ -106,12 +103,12 @@ This project is one of three [Wagtail](https://wagtail.org/) projects being spon
 
 ### Contributor
 
-- [Hitansh Shah](https://github.com/Hitansh-Shah)
+-   [Hitansh Shah](https://github.com/Hitansh-Shah)
 
 ### Mentors
 
-- [Thibaud Colas](https://github.com/thibaudcolas)
-- [Coen van der Kamp](https://github.com/allcaps)
-- [Meagen Voss](https://github.com/vossisboss)
+-   [Thibaud Colas](https://github.com/thibaudcolas)
+-   [Coen van der Kamp](https://github.com/allcaps)
+-   [Meagen Voss](https://github.com/vossisboss)
 
 You can learn more about our Google Summer of Code project in [Google Summer of Code: Wagtail Editor Guide](https://wagtail.org/blog/google-summer-of-code-wagtail-editor-guide/), [Wagtail CMS projects for Google Summer of Code 2022](https://wagtail.org/blog/wagtail-cms-projects-for-google-summer-of-code-2022/) or on our [wiki page](https://github.com/wagtail/wagtail/wiki/Google-Summer-of-Code-2022).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   web:
     build:
       context: .
+      target: dev
       args:
         UV_SYNC_ARGS: '--all-groups'
     ports:
@@ -15,6 +16,12 @@ services:
     volumes:
       - .:/app
       - staticfiles:/app/static
+      # Keeps node_modules (installed into the dev image, see Dockerfile) from
+      # being shadowed by the bind mount above. Since Docker keeps this
+      # directory's contents separate from the host, run npm/Node commands
+      # consistently from inside the container (not from the host) so they
+      # see the same node_modules.
+      - node_modules:/app/node_modules
     command:
       - uv
       - run
@@ -22,6 +29,7 @@ services:
       - manage.py
       - runserver
       - '0.0.0.0:${PORT:-8000}'
+    init: true
     depends_on:
       db:
         condition: service_healthy
@@ -48,4 +56,5 @@ services:
       retries: 5
 volumes:
   staticfiles:
+  node_modules:
   pgdata:

--- a/justfile
+++ b/justfile
@@ -94,29 +94,3 @@ eval-promptfoo-view:
 # Browse translation eval results in the Inspect viewer.
 eval-view:
     uvx --from inspect-ai --python 3.12 inspect view --log-dir prompts/evals/translations-inspect_ai/logs
-
-# Build the Docker image.
-docker-build:
-    docker compose build
-
-# Run the Docker container in the foreground.
-docker-run:
-    docker compose up --remove-orphans
-
-# Run the Docker container in the background.
-docker-start:
-    docker compose up --remove-orphans -d
-
-# Stop the Docker container.
-docker-stop:
-    docker compose down
-
-# Open a shell in the running Docker container.
-docker-exec:
-    docker compose exec web /bin/bash
-
-# Initialise the project inside the Docker container.
-docker-init:
-    docker compose exec web uv run python manage.py migrate
-    docker compose exec web uv run python manage.py createcachetable
-    docker compose exec web uv run python manage.py createsuperuser


### PR DESCRIPTION
## Summary

Follows up on #482 (migration ordering, still unresolved/environment-specific). This greatly simplifies the Docker setup, so you can just run:

```
docker compose up
docker compose exec web bash
```

…and then all the commands should be the same inside the container.

## Test plan

- [ ] `docker compose build` succeeds
- [ ] `docker compose up --remove-orphans` starts cleanly
- [ ] `docker compose exec web bash`, then `just backend` and `just frontend` succeed
- [ ] Site at `http://localhost:8000` renders with CSS/JS (the original bug)
- [ ] CI's new `docker-build-check` job passes